### PR TITLE
ci: standardize protected NuGet release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,79 +1,98 @@
 name: Release
 
+run-name: "Release ${{ inputs.version || 'dry-run' }} from ${{ github.ref_name }}"
+
 on:
-  push:
+  pull_request:
     branches:
-      - release/3.0.0-rc.1
+      - master
+    paths:
+      - .github/workflows/release.yml
+      - Directory.Build.props
+      - global.json
+      - Dapper.FluentMap.sln
+      - README.md
+      - eng/validate-release-artifacts.ps1
+      - eng/consumer-smoke/**
+      - src/**
   workflow_dispatch:
     inputs:
-      package-version:
-        description: "NuGet package version to validate and pack, for example 3.0.0-rc.1."
+      version:
+        description: "Exact Semantic Version to publish, for example 3.0.0-rc.1 or 3.0.0."
         required: true
-        default: "3.0.0-rc.1"
+        type: string
       publish:
-        description: "Reserved for a future approval-based NuGet publish flow. Publishing is disabled in this workflow."
+        description: "Publish the validated packages and GitHub Release."
         required: true
-        type: boolean
         default: false
-
-env:
-  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
-  CI: "true"
-  PACKAGE_VERSION: ${{ inputs.package-version || '3.0.0-rc.1' }}
-  PUBLISH_REQUESTED: ${{ inputs.publish && 'true' || 'false' }}
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ inputs.package-version }}
+  group: "release-${{ github.ref }}"
   cancel-in-progress: false
 
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+  DOTNET_NOLOGO: "true"
+  CI: "true"
+
 jobs:
-  validate-package:
-    name: Validate release package
+  build:
+    name: Build release artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      version: "${{ steps.release-metadata.outputs.version }}"
+      tag: "${{ steps.release-metadata.outputs.tag }}"
+      is-prerelease: "${{ steps.release-metadata.outputs.is_prerelease }}"
 
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
           persist-credentials: false
           show-progress: false
 
-      - name: Setup .NET
+      - name: Setup .NET SDK
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           global-json-file: global.json
 
-      - name: Validate release input
-        shell: pwsh
+      - name: Resolve release metadata
+        id: release-metadata
+        shell: bash
+        env:
+          REQUESTED_VERSION: "${{ inputs.version || format('0.0.0-ci.{0}', github.run_number) }}"
         run: |
-          $ErrorActionPreference = 'Stop'
-          $version = '${{ env.PACKAGE_VERSION }}'
+          set -euo pipefail
 
-          if ($version -notmatch '^\d+\.\d+\.\d+(-[0-9A-Za-z][0-9A-Za-z.-]*)$') {
-            throw "Package version '$version' is not a supported SemVer value."
-          }
+          version="${REQUESTED_VERSION}"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "Version '${version}' is not a supported Semantic Version. Build metadata (+...) is intentionally not accepted." >&2
+            exit 2
+          fi
 
-          if ($version -ne '3.0.0-rc.1') {
-            throw "This release workflow is locked to 3.0.0-rc.1. Received '$version'."
-          }
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            major="${version%%.*}"
+            if (( major < 3 )); then
+              echo "Official FluentMap releases from this workflow must use major version 3 or later." >&2
+              exit 2
+            fi
+          fi
 
-          $ref = '${{ github.ref }}'
-          if ($ref -ne 'refs/heads/release/3.0.0-rc.1') {
-            throw "This release workflow is locked to refs/heads/release/3.0.0-rc.1. Received '$ref'."
-          }
+          is_prerelease=false
+          if [[ "${version}" == *-* ]]; then
+            is_prerelease=true
+          fi
 
-      - name: Guard disabled publish path
-        if: ${{ env.PUBLISH_REQUESTED == 'true' }}
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          throw "NuGet publishing is intentionally disabled. Configure NuGet trusted publishing/OIDC and an approval environment before enabling publish."
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
+          echo "is_prerelease=${is_prerelease}" >> "${GITHUB_OUTPUT}"
 
       - name: Show .NET info
         run: dotnet --info
@@ -85,28 +104,50 @@ jobs:
         run: dotnet list ./Dapper.FluentMap.sln package --vulnerable --include-transitive
 
       - name: Build Release
-        run: dotnet build ./Dapper.FluentMap.sln --configuration Release --no-restore -p:Version=${{ env.PACKAGE_VERSION }}
+        env:
+          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
+        run: >-
+          dotnet build ./Dapper.FluentMap.sln
+          --configuration Release
+          --no-restore
+          -p:Version=${RELEASE_VERSION}
+          -p:RepositoryCommit=${GITHUB_SHA}
+          -p:RepositoryBranch=${GITHUB_REF}
+          -p:ContinuousIntegrationBuild=true
 
       - name: Test Release
-        run: dotnet test ./Dapper.FluentMap.sln --configuration Release --no-build
+        run: dotnet test ./Dapper.FluentMap.sln --configuration Release --no-build --no-restore
 
-      - name: Pack Release
-        run: dotnet pack ./Dapper.FluentMap.sln --configuration Release --no-build --output ./artifacts/packages -p:Version=${{ env.PACKAGE_VERSION }}
+      - name: Pack exact release version
+        env:
+          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
+        run: >-
+          dotnet pack ./Dapper.FluentMap.sln
+          --configuration Release
+          --no-build
+          --no-restore
+          --output ./artifacts/packages
+          -p:Version=${RELEASE_VERSION}
+          -p:RepositoryCommit=${GITHUB_SHA}
+          -p:RepositoryBranch=${GITHUB_REF}
+          -p:ContinuousIntegrationBuild=true
 
       - name: Validate release artifacts and write manifest
         shell: pwsh
+        env:
+          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
         run: |
           $ErrorActionPreference = 'Stop'
           ./eng/validate-release-artifacts.ps1 `
             -PackageDirectory './artifacts/packages' `
-            -Version '${{ env.PACKAGE_VERSION }}' `
+            -Version $env:RELEASE_VERSION `
             -ManifestPath './artifacts/release-metadata/artifact-manifest.json' `
             -Repository '${{ github.repository }}' `
             -RepositoryUrl 'https://github.com/${{ github.repository }}' `
             -Commit '${{ github.sha }}' `
             -Branch '${{ github.ref }}'
 
-      - name: Consumer smoke release packages
+      - name: Consumer smoke test release packages
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
@@ -121,45 +162,201 @@ jobs:
           dotnet list ./Dapper.FluentMap.sln package --include-transitive --format json |
             Set-Content -Encoding utf8NoBOM -Path './artifacts/release-metadata/dependencies.json'
 
-      - name: Upload release package artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: release-packages-${{ env.PACKAGE_VERSION }}
-          path: |
-            ./artifacts/packages/*.nupkg
-            ./artifacts/packages/*.snupkg
-            ./artifacts/release-metadata/*.json
-          if-no-files-found: error
-          retention-days: 90
-
-  provenance:
-    name: Attest release package provenance
-    runs-on: ubuntu-latest
-    needs: validate-package
-    timeout-minutes: 10
-    permissions:
-      contents: read
-      id-token: write
-      attestations: write
-
-    steps:
-      - name: Download release package artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: release-packages-${{ env.PACKAGE_VERSION }}
-          path: ./artifacts/release
-
-      - name: Collect package subjects
+      - name: Generate release checksums
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          New-Item -ItemType Directory -Force -Path './artifacts/attestation-subjects' | Out-Null
-          Get-ChildItem -Path './artifacts/release' -Recurse -File -Include '*.nupkg', '*.snupkg' |
-            Copy-Item -Destination './artifacts/attestation-subjects'
+          $artifactRoot = (Resolve-Path './artifacts').Path
+          $files = @(
+            Get-ChildItem './artifacts/packages' -File -Include '*.nupkg', '*.snupkg'
+            Get-Item './artifacts/release-metadata/artifact-manifest.json'
+            Get-Item './artifacts/release-metadata/dependencies.json'
+          ) | Sort-Object FullName
 
-      - name: Attest package provenance
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+          $lines = foreach ($file in $files) {
+            $relative = [System.IO.Path]::GetRelativePath($artifactRoot, $file.FullName).Replace('\', '/')
+            $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
+            "$hash  $relative"
+          }
+
+          $checksumPath = Join-Path $artifactRoot 'release-metadata/SHA256SUMS'
+          [System.IO.File]::WriteAllLines($checksumPath, $lines, [System.Text.UTF8Encoding]::new($false))
+
+      - name: Upload validated release candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: "release-candidate-${{ steps.release-metadata.outputs.version }}"
+          path: ./artifacts
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    name: Publish official release
+    if: "${{ github.event_name == 'workflow_dispatch' && inputs.publish }}"
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Validate protected publication request
+        shell: bash
+        env:
+          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
+          RELEASE_TAG: "${{ needs.build.outputs.tag }}"
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF}" != "refs/heads/master" ]]; then
+            echo "Official publication is allowed only from refs/heads/master." >&2
+            exit 2
+          fi
+
+          if [[ "${RELEASE_TAG}" != "v${RELEASE_VERSION}" ]]; then
+            echo "Resolved release tag must be exactly v${RELEASE_VERSION}." >&2
+            exit 2
+          fi
+
+      - name: Checkout exact release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: "${{ github.sha }}"
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Download validated release candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: "release-candidate-${{ needs.build.outputs.version }}"
+          path: ./artifacts
+
+      - name: Verify downloaded release candidate checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ./artifacts
+          sha256sum --check ./release-metadata/SHA256SUMS
+
+      - name: Revalidate downloaded package set
+        shell: pwsh
+        env:
+          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./eng/validate-release-artifacts.ps1 `
+            -PackageDirectory './artifacts/packages' `
+            -Version $env:RELEASE_VERSION `
+            -ManifestPath (Join-Path $env:RUNNER_TEMP 'reverified-artifact-manifest.json') `
+            -Repository '${{ github.repository }}' `
+            -RepositoryUrl 'https://github.com/${{ github.repository }}' `
+            -Commit '${{ github.sha }}' `
+            -Branch 'refs/heads/master'
+
+      - name: Attest release artifacts
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: |
-            ./artifacts/attestation-subjects/*.nupkg
-            ./artifacts/attestation-subjects/*.snupkg
+            ./artifacts/packages/*.nupkg
+            ./artifacts/packages/*.snupkg
+            ./artifacts/release-metadata/artifact-manifest.json
+            ./artifacts/release-metadata/dependencies.json
+            ./artifacts/release-metadata/SHA256SUMS
+
+      - name: Create or resume draft GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: "${{ github.token }}"
+          RELEASE_TAG: "${{ needs.build.outputs.tag }}"
+          IS_PRERELEASE: "${{ needs.build.outputs.is-prerelease }}"
+        run: |
+          set -euo pipefail
+
+          git fetch --force --tags origin
+          if git show-ref --tags --verify --quiet "refs/tags/${RELEASE_TAG}"; then
+            existing_commit="$(git rev-list -n 1 "${RELEASE_TAG}")"
+            if [[ "${existing_commit}" != "${GITHUB_SHA}" ]]; then
+              echo "Tag ${RELEASE_TAG} already points to ${existing_commit}, not ${GITHUB_SHA}." >&2
+              exit 3
+            fi
+          fi
+
+          release_state="$(gh release view "${RELEASE_TAG}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
+          if [[ "${release_state}" == "false" ]]; then
+            echo "Release ${RELEASE_TAG} is already published; refusing to mutate an immutable release." >&2
+            exit 3
+          fi
+
+          prerelease_args=()
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            prerelease_args+=(--prerelease)
+          fi
+
+          if [[ -z "${release_state}" ]]; then
+            if git show-ref --tags --verify --quiet "refs/tags/${RELEASE_TAG}"; then
+              gh release create "${RELEASE_TAG}" \
+                --verify-tag \
+                --draft \
+                --generate-notes \
+                --title "${RELEASE_TAG}" \
+                "${prerelease_args[@]}"
+            else
+              gh release create "${RELEASE_TAG}" \
+                --target "${GITHUB_SHA}" \
+                --draft \
+                --generate-notes \
+                --title "${RELEASE_TAG}" \
+                "${prerelease_args[@]}"
+            fi
+          fi
+
+          gh release upload "${RELEASE_TAG}" \
+            ./artifacts/packages/* \
+            ./artifacts/release-metadata/* \
+            --clobber
+
+      - name: Authenticate to NuGet.org with trusted publishing
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: "${{ vars.NUGET_USER }}"
+
+      - name: Publish NuGet packages
+        shell: pwsh
+        env:
+          NUGET_API_KEY: "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
+          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $packageIds = @(
+            'Dapper.FluentMap',
+            'Dapper.FluentMap.Dommel',
+            'Dapper.FluentMap.DependencyInjection',
+            'Dapper.FluentMap.Analyzers',
+            'Dapper.FluentMap.Generators'
+          )
+
+          foreach ($packageId in $packageIds) {
+            $package = "./artifacts/packages/$packageId.$env:RELEASE_VERSION.nupkg"
+            dotnet nuget push $package `
+              --source 'https://api.nuget.org/v3/index.json' `
+              --api-key $env:NUGET_API_KEY `
+              --skip-duplicate
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "NuGet publication failed for $packageId."
+            }
+          }
+
+      - name: Publish GitHub Release
+        shell: bash
+        env:
+          GH_TOKEN: "${{ github.token }}"
+          RELEASE_TAG: "${{ needs.build.outputs.tag }}"
+        run: |
+          set -euo pipefail
+          gh release edit "${RELEASE_TAG}" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,24 @@ jobs:
 
       - name: Consumer smoke test release packages
         shell: pwsh
+        env:
+          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
         run: |
           $ErrorActionPreference = 'Stop'
+
+          # The existing consumer fixtures were created for 3.0.0-rc.1. Rewrite only
+          # their package-version literals in the CI workspace so the same smoke suite
+          # validates the exact package version produced by this run.
+          Get-ChildItem './eng/consumer-smoke' -Recurse -File |
+            Where-Object { $_.Extension -in @('.csproj', '.ps1') } |
+            ForEach-Object {
+              $content = Get-Content -LiteralPath $_.FullName -Raw
+              $updated = $content.Replace('3.0.0-rc.1', $env:RELEASE_VERSION)
+              if ($updated -ne $content) {
+                [System.IO.File]::WriteAllText($_.FullName, $updated, [System.Text.UTF8Encoding]::new($false))
+              }
+            }
+
           ./eng/consumer-smoke/run-consumer-smoke.ps1 `
             -PackageDirectory './artifacts/packages'
 
@@ -202,6 +218,7 @@ jobs:
       id-token: write
       attestations: write
       artifact-metadata: write
+      packages: write
 
     steps:
       - name: Validate protected publication request
@@ -325,7 +342,7 @@ jobs:
         with:
           user: "${{ vars.NUGET_USER }}"
 
-      - name: Publish NuGet packages
+      - name: Publish packages to NuGet.org
         shell: pwsh
         env:
           NUGET_API_KEY: "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
@@ -348,7 +365,45 @@ jobs:
               --skip-duplicate
 
             if ($LASTEXITCODE -ne 0) {
-              throw "NuGet publication failed for $packageId."
+              throw "NuGet.org publication failed for $packageId."
+            }
+          }
+
+      - name: Configure GitHub Packages source
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+        run: >-
+          dotnet nuget add source
+          --username "${{ github.actor }}"
+          --password "${GITHUB_TOKEN}"
+          --store-password-in-clear-text
+          --name github
+          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+
+      - name: Publish packages to GitHub Packages
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"
+          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $packageIds = @(
+            'Dapper.FluentMap',
+            'Dapper.FluentMap.Dommel',
+            'Dapper.FluentMap.DependencyInjection',
+            'Dapper.FluentMap.Analyzers',
+            'Dapper.FluentMap.Generators'
+          )
+
+          foreach ($packageId in $packageIds) {
+            $package = "./artifacts/packages/$packageId.$env:RELEASE_VERSION.nupkg"
+            dotnet nuget push $package `
+              --source github `
+              --api-key $env:GITHUB_TOKEN `
+              --skip-duplicate
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "GitHub Packages publication failed for $packageId."
             }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,8 +187,17 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $artifactRoot = (Resolve-Path './artifacts').Path
+          $packageFiles = @(
+            Get-ChildItem './artifacts/packages' -File |
+              Where-Object { $_.Extension -in @('.nupkg', '.snupkg') }
+          )
+
+          if ($packageFiles.Count -ne 8) {
+            throw "Expected 8 package artifacts for checksums, found $($packageFiles.Count)."
+          }
+
           $files = @(
-            Get-ChildItem './artifacts/packages' -File -Include '*.nupkg', '*.snupkg'
+            $packageFiles
             Get-Item './artifacts/release-metadata/artifact-manifest.json'
             Get-Item './artifacts/release-metadata/dependencies.json'
           ) | Sort-Object FullName
@@ -301,11 +310,10 @@ jobs:
             $package = "./artifacts/packages/$packageId.$env:PACKAGE_VERSION.nupkg"
             dotnet nuget push $package `
               --source 'https://api.nuget.org/v3/index.json' `
-              --api-key $env:NUGET_API_KEY `
-              --skip-duplicate
+              --api-key $env:NUGET_API_KEY
 
             if ($LASTEXITCODE -ne 0) {
-              throw "NuGet.org publication failed for $packageId."
+              throw "NuGet.org publication failed for $packageId. The version may already exist; refusing to suppress an unverified duplicate."
             }
           }
 
@@ -359,11 +367,10 @@ jobs:
             $package = "./artifacts/packages/$packageId.$env:PACKAGE_VERSION.nupkg"
             dotnet nuget push $package `
               --source $env:GITHUB_PACKAGE_SOURCE `
-              --api-key $env:GITHUB_PACKAGE_TOKEN `
-              --skip-duplicate
+              --api-key $env:GITHUB_PACKAGE_TOKEN
 
             if ($LASTEXITCODE -ne 0) {
-              throw "GitHub Packages publication failed for $packageId."
+              throw "GitHub Packages publication failed for $packageId. The version may already exist; refusing to suppress an unverified duplicate."
             }
           }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,37 +1,20 @@
 name: Release
 
-run-name: "Release ${{ inputs.version || 'dry-run' }} from ${{ github.ref_name }}"
+run-name: "Release ${{ inputs.version }} from ${{ github.ref_name }}"
 
 on:
-  pull_request:
-    branches:
-      - master
-    paths:
-      - .github/workflows/release.yml
-      - Directory.Build.props
-      - global.json
-      - Dapper.FluentMap.sln
-      - README.md
-      - eng/validate-release-artifacts.ps1
-      - eng/consumer-smoke/**
-      - src/**
   workflow_dispatch:
     inputs:
       version:
-        description: "Exact Semantic Version to publish, for example 3.0.0-rc.1 or 3.0.0."
+        description: "Semantic version without the v prefix, for example 3.0.0-rc.1 or 3.0.0."
         required: true
         type: string
-      publish:
-        description: "Publish the validated packages and GitHub Release."
-        required: true
-        default: false
-        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
-  group: "release-${{ github.ref }}"
+  group: release
   cancel-in-progress: false
 
 env:
@@ -41,58 +24,82 @@ env:
   CI: "true"
 
 jobs:
-  build:
-    name: Build release artifacts
+  build-and-pack:
+    name: Validate, build, test and pack
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: read
     outputs:
-      version: "${{ steps.release-metadata.outputs.version }}"
-      tag: "${{ steps.release-metadata.outputs.tag }}"
-      is-prerelease: "${{ steps.release-metadata.outputs.is_prerelease }}"
+      package-version: ${{ steps.version.outputs.package_version }}
+      release-tag: ${{ steps.version.outputs.release_tag }}
+      is-prerelease: ${{ steps.version.outputs.is_prerelease }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
           show-progress: false
 
-      - name: Setup .NET SDK
+      - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           global-json-file: global.json
 
-      - name: Resolve release metadata
-        id: release-metadata
+      - name: Validate release version
+        id: version
         shell: bash
         env:
-          REQUESTED_VERSION: "${{ inputs.version || format('0.0.0-ci.{0}', github.run_number) }}"
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
-          version="${REQUESTED_VERSION}"
-          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
-            echo "Version '${version}' is not a supported Semantic Version. Build metadata (+...) is intentionally not accepted." >&2
-            exit 2
+          if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+            echo "::error::Releases must be started from the master branch. Current ref: $GITHUB_REF"
+            exit 1
           fi
 
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            major="${version%%.*}"
-            if (( major < 3 )); then
-              echo "Official FluentMap releases from this workflow must use major version 3 or later." >&2
-              exit 2
-            fi
+          if [[ "$VERSION" == v* ]]; then
+            echo "::error::Enter the semantic version without the 'v' prefix (for example 3.0.0-rc.1)."
+            exit 1
           fi
 
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$VERSION" =~ $semver ]]; then
+            echo "::error::Invalid semantic version '$VERSION'. Expected a value such as 3.0.0-rc.1 or 3.0.0."
+            exit 1
+          fi
+
+          major="${VERSION%%.*}"
+          if (( major < 3 )); then
+            echo "::error::FluentMap releases from this workflow must use major version 3 or later."
+            exit 1
+          fi
+
+          release_tag="v$VERSION"
           is_prerelease=false
-          if [[ "${version}" == *-* ]]; then
+          if [[ "$VERSION" == *-* ]]; then
             is_prerelease=true
           fi
 
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
-          echo "is_prerelease=${is_prerelease}" >> "${GITHUB_OUTPUT}"
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "$release_tag")"
+            if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
+              echo "::error::Tag '$release_tag' already exists and points to $tag_sha instead of $GITHUB_SHA."
+              exit 1
+            fi
+
+            echo "Tag '$release_tag' already exists on the validated commit; this run can be safely retried."
+          fi
+
+          echo "package_version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
+          echo "Release version: $VERSION"
+          echo "Release tag: $release_tag"
 
       - name: Show .NET info
         run: dotnet --info
@@ -103,31 +110,31 @@ jobs:
       - name: Audit NuGet dependencies
         run: dotnet list ./Dapper.FluentMap.sln package --vulnerable --include-transitive
 
-      - name: Build Release
+      - name: Build release
         env:
-          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
         run: >-
           dotnet build ./Dapper.FluentMap.sln
           --configuration Release
           --no-restore
-          -p:Version=${RELEASE_VERSION}
+          -p:Version=${PACKAGE_VERSION}
           -p:RepositoryCommit=${GITHUB_SHA}
           -p:RepositoryBranch=${GITHUB_REF}
           -p:ContinuousIntegrationBuild=true
 
-      - name: Test Release
+      - name: Run tests
         run: dotnet test ./Dapper.FluentMap.sln --configuration Release --no-build --no-restore
 
-      - name: Pack exact release version
+      - name: Pack release
         env:
-          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
         run: >-
           dotnet pack ./Dapper.FluentMap.sln
           --configuration Release
           --no-build
           --no-restore
           --output ./artifacts/packages
-          -p:Version=${RELEASE_VERSION}
+          -p:Version=${PACKAGE_VERSION}
           -p:RepositoryCommit=${GITHUB_SHA}
           -p:RepositoryBranch=${GITHUB_REF}
           -p:ContinuousIntegrationBuild=true
@@ -135,12 +142,12 @@ jobs:
       - name: Validate release artifacts and write manifest
         shell: pwsh
         env:
-          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
         run: |
           $ErrorActionPreference = 'Stop'
           ./eng/validate-release-artifacts.ps1 `
             -PackageDirectory './artifacts/packages' `
-            -Version $env:RELEASE_VERSION `
+            -Version $env:PACKAGE_VERSION `
             -ManifestPath './artifacts/release-metadata/artifact-manifest.json' `
             -Repository '${{ github.repository }}' `
             -RepositoryUrl 'https://github.com/${{ github.repository }}' `
@@ -150,18 +157,15 @@ jobs:
       - name: Consumer smoke test release packages
         shell: pwsh
         env:
-          RELEASE_VERSION: "${{ steps.release-metadata.outputs.version }}"
+          PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
         run: |
           $ErrorActionPreference = 'Stop'
 
-          # The existing consumer fixtures were created for 3.0.0-rc.1. Rewrite only
-          # their package-version literals in the CI workspace so the same smoke suite
-          # validates the exact package version produced by this run.
           Get-ChildItem './eng/consumer-smoke' -Recurse -File |
             Where-Object { $_.Extension -in @('.csproj', '.ps1') } |
             ForEach-Object {
               $content = Get-Content -LiteralPath $_.FullName -Raw
-              $updated = $content.Replace('3.0.0-rc.1', $env:RELEASE_VERSION)
+              $updated = $content.Replace('3.0.0-rc.1', $env:PACKAGE_VERSION)
               if ($updated -ne $content) {
                 [System.IO.File]::WriteAllText($_.FullName, $updated, [System.Text.UTF8Encoding]::new($false))
               }
@@ -190,7 +194,7 @@ jobs:
           ) | Sort-Object FullName
 
           $lines = foreach ($file in $files) {
-            $relative = [System.IO.Path]::GetRelativePath($artifactRoot, $file.FullName).Replace('\', '/')
+            $relative = [System.IO.Path]::GetRelativePath($artifactRoot, $file.FullName).Replace('\\', '/')
             $hash = (Get-FileHash -LiteralPath $file.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
             "$hash  $relative"
           }
@@ -198,81 +202,198 @@ jobs:
           $checksumPath = Join-Path $artifactRoot 'release-metadata/SHA256SUMS'
           [System.IO.File]::WriteAllLines($checksumPath, $lines, [System.Text.UTF8Encoding]::new($false))
 
-      - name: Upload validated release candidate
+      - name: Upload release package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: "release-candidate-${{ steps.release-metadata.outputs.version }}"
+          name: release-package
           path: ./artifacts
           if-no-files-found: error
           retention-days: 14
 
-  publish:
-    name: Publish official release
-    if: "${{ github.event_name == 'workflow_dispatch' && inputs.publish }}"
-    needs: build
+  ensure-release-tag:
+    name: Create release tag
+    needs: build-and-pack
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    environment: release
     permissions:
       contents: write
-      id-token: write
-      attestations: write
-      artifact-metadata: write
-      packages: write
 
     steps:
-      - name: Validate protected publication request
+      - name: Checkout validated commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Create or verify tag
         shell: bash
         env:
-          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
-          RELEASE_TAG: "${{ needs.build.outputs.tag }}"
+          RELEASE_TAG: ${{ needs.build-and-pack.outputs.release-tag }}
+          VALIDATED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          if [[ "${GITHUB_REF}" != "refs/heads/master" ]]; then
-            echo "Official publication is allowed only from refs/heads/master." >&2
-            exit 2
+          git fetch --tags --force
+          if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
+            tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
+            if [[ "$tag_sha" != "$VALIDATED_SHA" ]]; then
+              echo "::error::Tag '$RELEASE_TAG' points to $tag_sha instead of $VALIDATED_SHA."
+              exit 1
+            fi
+
+            echo "Tag '$RELEASE_TAG' already exists on the validated commit."
+            exit 0
           fi
 
-          if [[ "${RELEASE_TAG}" != "v${RELEASE_VERSION}" ]]; then
-            echo "Resolved release tag must be exactly v${RELEASE_VERSION}." >&2
-            exit 2
-          fi
+          git tag "$RELEASE_TAG" "$VALIDATED_SHA"
+          git push origin "refs/tags/$RELEASE_TAG"
 
-      - name: Checkout exact release commit
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+  publish-nuget:
+    name: Publish to NuGet.org
+    needs:
+      - build-and-pack
+      - ensure-release-tag
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
-          ref: "${{ github.sha }}"
-          fetch-depth: 0
-          persist-credentials: false
+          global-json-file: global.json
 
-      - name: Download validated release candidate
+      - name: Download release package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: "release-candidate-${{ needs.build.outputs.version }}"
+          name: release-package
           path: ./artifacts
 
-      - name: Verify downloaded release candidate checksums
+      - name: Verify release checksums
         shell: bash
         run: |
           set -euo pipefail
           cd ./artifacts
           sha256sum --check ./release-metadata/SHA256SUMS
 
-      - name: Revalidate downloaded package set
+      - name: Exchange GitHub OIDC token for temporary NuGet API key
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: "${{ vars.NUGET_USER }}"
+
+      - name: Publish to NuGet.org
         shell: pwsh
         env:
-          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          PACKAGE_VERSION: ${{ needs.build-and-pack.outputs.package-version }}
         run: |
           $ErrorActionPreference = 'Stop'
-          ./eng/validate-release-artifacts.ps1 `
-            -PackageDirectory './artifacts/packages' `
-            -Version $env:RELEASE_VERSION `
-            -ManifestPath (Join-Path $env:RUNNER_TEMP 'reverified-artifact-manifest.json') `
-            -Repository '${{ github.repository }}' `
-            -RepositoryUrl 'https://github.com/${{ github.repository }}' `
-            -Commit '${{ github.sha }}' `
-            -Branch 'refs/heads/master'
+          $packageIds = @(
+            'Dapper.FluentMap',
+            'Dapper.FluentMap.Dommel',
+            'Dapper.FluentMap.DependencyInjection',
+            'Dapper.FluentMap.Analyzers',
+            'Dapper.FluentMap.Generators'
+          )
+
+          foreach ($packageId in $packageIds) {
+            $package = "./artifacts/packages/$packageId.$env:PACKAGE_VERSION.nupkg"
+            dotnet nuget push $package `
+              --source 'https://api.nuget.org/v3/index.json' `
+              --api-key $env:NUGET_API_KEY `
+              --skip-duplicate
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "NuGet.org publication failed for $packageId."
+            }
+          }
+
+  publish-github-packages:
+    name: Publish to GitHub Packages
+    needs:
+      - build-and-pack
+      - ensure-release-tag
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          global-json-file: global.json
+
+      - name: Download release package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-package
+          path: ./artifacts
+
+      - name: Verify release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ./artifacts
+          sha256sum --check ./release-metadata/SHA256SUMS
+
+      - name: Publish to GitHub Packages
+        shell: pwsh
+        env:
+          GITHUB_PACKAGE_SOURCE: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+          GITHUB_PACKAGE_TOKEN: ${{ github.token }}
+          PACKAGE_VERSION: ${{ needs.build-and-pack.outputs.package-version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $packageIds = @(
+            'Dapper.FluentMap',
+            'Dapper.FluentMap.Dommel',
+            'Dapper.FluentMap.DependencyInjection',
+            'Dapper.FluentMap.Analyzers',
+            'Dapper.FluentMap.Generators'
+          )
+
+          foreach ($packageId in $packageIds) {
+            $package = "./artifacts/packages/$packageId.$env:PACKAGE_VERSION.nupkg"
+            dotnet nuget push $package `
+              --source $env:GITHUB_PACKAGE_SOURCE `
+              --api-key $env:GITHUB_PACKAGE_TOKEN `
+              --skip-duplicate
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "GitHub Packages publication failed for $packageId."
+            }
+          }
+
+  github-release:
+    name: Create GitHub Release
+    needs:
+      - build-and-pack
+      - ensure-release-tag
+      - publish-nuget
+      - publish-github-packages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
+
+    steps:
+      - name: Download release package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-package
+          path: ./artifacts
+
+      - name: Verify release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ./artifacts
+          sha256sum --check ./release-metadata/SHA256SUMS
 
       - name: Attest release artifacts
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
@@ -284,134 +405,34 @@ jobs:
             ./artifacts/release-metadata/dependencies.json
             ./artifacts/release-metadata/SHA256SUMS
 
-      - name: Create or resume draft GitHub Release
+      - name: Create or update GitHub Release
         shell: bash
         env:
-          GH_TOKEN: "${{ github.token }}"
-          RELEASE_TAG: "${{ needs.build.outputs.tag }}"
-          IS_PRERELEASE: "${{ needs.build.outputs.is-prerelease }}"
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.build-and-pack.outputs.release-tag }}
+          IS_PRERELEASE: ${{ needs.build-and-pack.outputs.is-prerelease }}
         run: |
           set -euo pipefail
 
-          git fetch --force --tags origin
-          if git show-ref --tags --verify --quiet "refs/tags/${RELEASE_TAG}"; then
-            existing_commit="$(git rev-list -n 1 "${RELEASE_TAG}")"
-            if [[ "${existing_commit}" != "${GITHUB_SHA}" ]]; then
-              echo "Tag ${RELEASE_TAG} already points to ${existing_commit}, not ${GITHUB_SHA}." >&2
-              exit 3
-            fi
-          fi
-
-          release_state="$(gh release view "${RELEASE_TAG}" --json isDraft --jq '.isDraft' 2>/dev/null || true)"
-          if [[ "${release_state}" == "false" ]]; then
-            echo "Release ${RELEASE_TAG} is already published; refusing to mutate an immutable release." >&2
-            exit 3
-          fi
-
-          prerelease_args=()
-          if [[ "${IS_PRERELEASE}" == "true" ]]; then
-            prerelease_args+=(--prerelease)
-          fi
-
-          if [[ -z "${release_state}" ]]; then
-            if git show-ref --tags --verify --quiet "refs/tags/${RELEASE_TAG}"; then
-              gh release create "${RELEASE_TAG}" \
-                --verify-tag \
-                --draft \
-                --generate-notes \
-                --title "${RELEASE_TAG}" \
-                "${prerelease_args[@]}"
-            else
-              gh release create "${RELEASE_TAG}" \
-                --target "${GITHUB_SHA}" \
-                --draft \
-                --generate-notes \
-                --title "${RELEASE_TAG}" \
-                "${prerelease_args[@]}"
-            fi
-          fi
-
-          gh release upload "${RELEASE_TAG}" \
-            ./artifacts/packages/* \
-            ./artifacts/release-metadata/* \
-            --clobber
-
-      - name: Authenticate to NuGet.org with trusted publishing
-        id: nuget-login
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-        with:
-          user: "${{ vars.NUGET_USER }}"
-
-      - name: Publish packages to NuGet.org
-        shell: pwsh
-        env:
-          NUGET_API_KEY: "${{ steps.nuget-login.outputs.NUGET_API_KEY }}"
-          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $packageIds = @(
-            'Dapper.FluentMap',
-            'Dapper.FluentMap.Dommel',
-            'Dapper.FluentMap.DependencyInjection',
-            'Dapper.FluentMap.Analyzers',
-            'Dapper.FluentMap.Generators'
+          assets=(
+            ./artifacts/packages/*.nupkg
+            ./artifacts/packages/*.snupkg
+            ./artifacts/release-metadata/*
           )
 
-          foreach ($packageId in $packageIds) {
-            $package = "./artifacts/packages/$packageId.$env:RELEASE_VERSION.nupkg"
-            dotnet nuget push $package `
-              --source 'https://api.nuget.org/v3/index.json' `
-              --api-key $env:NUGET_API_KEY `
-              --skip-duplicate
+          if gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+            echo "GitHub Release '$RELEASE_TAG' already exists; refreshing release artifacts."
+            gh release upload "$RELEASE_TAG" "${assets[@]}" --repo "$GH_REPO" --clobber
+            exit 0
+          fi
 
-            if ($LASTEXITCODE -ne 0) {
-              throw "NuGet.org publication failed for $packageId."
-            }
-          }
+          release_args=(--verify-tag --generate-notes --title "$RELEASE_TAG")
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            release_args+=(--prerelease)
+          fi
 
-      - name: Configure GitHub Packages source
-        env:
-          GITHUB_TOKEN: "${{ github.token }}"
-        run: >-
-          dotnet nuget add source
-          --username "${{ github.actor }}"
-          --password "${GITHUB_TOKEN}"
-          --store-password-in-clear-text
-          --name github
-          "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
-
-      - name: Publish packages to GitHub Packages
-        shell: pwsh
-        env:
-          GITHUB_TOKEN: "${{ github.token }}"
-          RELEASE_VERSION: "${{ needs.build.outputs.version }}"
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $packageIds = @(
-            'Dapper.FluentMap',
-            'Dapper.FluentMap.Dommel',
-            'Dapper.FluentMap.DependencyInjection',
-            'Dapper.FluentMap.Analyzers',
-            'Dapper.FluentMap.Generators'
-          )
-
-          foreach ($packageId in $packageIds) {
-            $package = "./artifacts/packages/$packageId.$env:RELEASE_VERSION.nupkg"
-            dotnet nuget push $package `
-              --source github `
-              --api-key $env:GITHUB_TOKEN `
-              --skip-duplicate
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "GitHub Packages publication failed for $packageId."
-            }
-          }
-
-      - name: Publish GitHub Release
-        shell: bash
-        env:
-          GH_TOKEN: "${{ github.token }}"
-          RELEASE_TAG: "${{ needs.build.outputs.tag }}"
-        run: |
-          set -euo pipefail
-          gh release edit "${RELEASE_TAG}" --draft=false
+          gh release create "$RELEASE_TAG" \
+            "${assets[@]}" \
+            --repo "$GH_REPO" \
+            "${release_args[@]}"

--- a/eng/validate-release-artifacts.ps1
+++ b/eng/validate-release-artifacts.ps1
@@ -20,8 +20,6 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$candidateVersion = '3.0.0-rc.1'
-$candidateBranch = 'refs/heads/release/3.0.0-rc.1'
 $expectedRepositoryUrl = 'https://github.com/rodri-oliveira-dev/Dapper-FluentMap'
 $expectedNupkgIds = @(
   'Dapper.FluentMap',
@@ -38,7 +36,7 @@ $expectedSnupkgIds = @(
 $expectedDependencies = @{
   'Dapper.FluentMap' = @{
     'Dapper' = '[2.1.79, 3.0.0)'
-    'Microsoft.Bcl.AsyncInterfaces' = '10.0.8'
+    'Microsoft.Bcl.AsyncInterfaces' = '10.0.11'
   }
   'Dapper.FluentMap.Dommel' = @{
     'Dapper.FluentMap' = $Version
@@ -47,7 +45,7 @@ $expectedDependencies = @{
   }
   'Dapper.FluentMap.DependencyInjection' = @{
     'Dapper.FluentMap' = $Version
-    'Microsoft.Extensions.DependencyInjection.Abstractions' = '10.0.10'
+    'Microsoft.Extensions.DependencyInjection.Abstractions' = '10.0.11'
   }
   'Dapper.FluentMap.Analyzers' = @{}
   'Dapper.FluentMap.Generators' = @{}
@@ -90,7 +88,10 @@ function Get-ChildText {
     [string]$Name
   )
 
-  $child = $Node.ChildNodes | Where-Object { $_.LocalName -eq $Name } | Select-Object -First 1
+  $child = $Node.ChildNodes |
+    Where-Object { $_.LocalName -eq $Name } |
+    Select-Object -First 1
+
   if ($null -eq $child) {
     return $null
   }
@@ -235,17 +236,13 @@ function Assert-CommonPackageMetadata {
     Fail "$ExpectedId repository commit is '$($PackageInfo.RepositoryCommit)', expected '$Commit'."
   }
 
-  if ($Branch -ne '' -and $PackageInfo.RepositoryBranch -ne $Branch) {
+  if (-not [string]::IsNullOrWhiteSpace($Branch) -and $PackageInfo.RepositoryBranch -ne $Branch) {
     Fail "$ExpectedId repository branch is '$($PackageInfo.RepositoryBranch)', expected '$Branch'."
   }
 }
 
-if ($Version -ne $candidateVersion) {
-  Fail "This release gate only accepts version $candidateVersion; received '$Version'."
-}
-
-if ($Version -eq '2.0.0' -or $Version -eq '3.0.0' -or $Version -notmatch '-') {
-  Fail "Version '$Version' is not allowed for this release candidate."
+if ($Version -notmatch '^\d+\.\d+\.\d+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$') {
+  Fail "Version '$Version' is not a supported Semantic Version. Build metadata (+...) is intentionally not accepted."
 }
 
 if (-not (Test-Path -LiteralPath $PackageDirectory -PathType Container)) {
@@ -305,10 +302,6 @@ if ([string]::IsNullOrWhiteSpace($Commit)) {
   Fail 'Repository commit could not be determined.'
 }
 
-if ($Branch -ne $candidateBranch) {
-  Fail "This release gate only accepts branch $candidateBranch; received '$Branch'."
-}
-
 if ($RepositoryUrl -ne $expectedRepositoryUrl) {
   Fail "Repository URL '$RepositoryUrl' is not the expected release repository '$expectedRepositoryUrl'."
 }
@@ -345,7 +338,13 @@ if ($forbiddenArtifacts.Count -gt 0) {
 $packageInfos = @{}
 foreach ($file in $nupkgs) {
   $info = Get-ZipPackageInfo -File $file
-  Assert-CommonPackageMetadata -PackageInfo $info -ExpectedId ($file.Name.Substring(0, $file.Name.Length - ".$Version.nupkg".Length))
+  $expectedId = $file.Name.Substring(0, $file.Name.Length - ".$Version.nupkg".Length)
+  Assert-CommonPackageMetadata -PackageInfo $info -ExpectedId $expectedId
+
+  if (-not $expectedDependencies.ContainsKey($info.Id)) {
+    Fail "Unexpected package ID '$($info.Id)' has no dependency contract."
+  }
+
   Assert-Dependencies -PackageId $info.Id -Actual $info.Dependencies -Expected $expectedDependencies[$info.Id]
 
   if ($packageInfos.ContainsKey($info.Id)) {
@@ -430,20 +429,21 @@ $manifest = [ordered]@{
   packages = @($manifestPackages)
 }
 
-$manifestDirectory = Split-Path -Parent $ManifestPath
+$manifestFullPath = [System.IO.Path]::GetFullPath($ManifestPath)
+$manifestDirectory = Split-Path -Parent $manifestFullPath
 if (-not [string]::IsNullOrWhiteSpace($manifestDirectory)) {
   New-Item -ItemType Directory -Force -Path $manifestDirectory | Out-Null
 }
 
 $manifestJson = $manifest | ConvertTo-Json -Depth 8
 [System.IO.File]::WriteAllText(
-  (Resolve-Path -LiteralPath (Split-Path -Parent $ManifestPath)).Path + [System.IO.Path]::DirectorySeparatorChar + (Split-Path -Leaf $ManifestPath),
+  $manifestFullPath,
   $manifestJson + [Environment]::NewLine,
   [System.Text.UTF8Encoding]::new($false))
 
-$validatedManifest = Get-Content -Raw -Path $ManifestPath | ConvertFrom-Json
+$validatedManifest = Get-Content -Raw -Path $manifestFullPath | ConvertFrom-Json
 if ($validatedManifest.version -ne $Version -or @($validatedManifest.packages).Count -ne 8) {
-  Fail "Generated manifest '$ManifestPath' did not round-trip with the expected version and package count."
+  Fail "Generated manifest '$manifestFullPath' did not round-trip with the expected version and package count."
 }
 
-Write-Host "Validated 5 .nupkg files, 3 .snupkg files and wrote manifest '$ManifestPath' for $Version."
+Write-Host "Validated 5 .nupkg files, 3 .snupkg files and wrote manifest '$manifestFullPath' for $Version."


### PR DESCRIPTION
## Summary

Aligns the Dapper.FluentMap release process with the staged release model used by `complexity-analyzers`, adapted for the five FluentMap packages.

### Observable release stages
The official `workflow_dispatch` release now appears in GitHub Actions as separate jobs:

1. **Validate, build, test and pack**
2. **Create release tag**
3. **Publish to NuGet.org** and **Publish to GitHub Packages** in parallel
4. **Create GitHub Release** only after both registries succeed

### Changes
- changes `release.yml` to an explicit `workflow_dispatch` release, matching the `complexity-analyzers` topology;
- accepts an exact SemVer input without the `v` prefix;
- restricts releases to `master` and major version 3+;
- validates an existing immutable release tag for safe reruns;
- keeps restore, vulnerability audit, full build/tests, package validation and consumer smoke testing before any publication;
- packages all 5 FluentMap NuGet packages once and reuses the exact validated artifact in downstream jobs;
- creates SHA-256 checksums and dependency/release manifests;
- creates or verifies `v<version>` only after validation succeeds;
- publishes NuGet.org through Trusted Publishing/OIDC;
- publishes the same 5 validated packages to GitHub Packages using the scoped `GITHUB_TOKEN`;
- makes both registry publication jobs use the protected `release` environment and run in parallel;
- creates the GitHub Release only after both registry publications succeed;
- keeps GitHub artifact attestations/provenance in the final release stage;
- keeps prerelease detection for tags such as `v3.0.0-rc.1`;
- updates artifact validation for current `10.0.11` dependencies;
- removes the old hardcoded release branch/version gates;
- makes the existing consumer-smoke fixtures validate the exact version selected for the release.

## Required repository/NuGet configuration before first publish
- GitHub Environment: `release` (recommended: required reviewer + deployment branch restricted to `master`);
- environment/repository variable `NUGET_USER` containing the NuGet.org account used by Trusted Publishing;
- NuGet.org Trusted Publishing policy trusting `rodri-oliveira-dev/Dapper-FluentMap`, `.github/workflows/release.yml`, and the `release` environment;
- ownership/publication rights for all NuGet.org package IDs, especially the historical `Dapper.FluentMap` and `Dapper.FluentMap.Dommel` packages.

GitHub Packages uses the workflow `GITHUB_TOKEN` with `packages: write`; no separate long-lived package token is stored.

## Release usage
1. Merge after normal CI is green.
2. Open **Actions → Release → Run workflow** on `master`.
3. Enter an exact version such as `3.0.0-rc.1`.
4. Observe each release stage independently in the Actions dependency graph.
