### PR TITLE
chore(nuget): refresh package metadata for current stewardship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,12 @@ jobs:
       - name: Pack Release
         run: dotnet pack ./Dapper.FluentMap.sln --configuration Release --no-build --output ./artifacts/packages
 
+      - name: Validate NuGet presentation metadata
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./eng/validate-package-metadata.ps1 -PackageDirectory './artifacts/packages'
+
       - name: Validate package artifact set
         shell: pwsh
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>https://github.com/rodri-oliveira-dev/Dapper-FluentMap/releases/tag/v$(PackageVersion)</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/rodri-oliveira-dev/Dapper-FluentMap/releases</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,11 +18,13 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <Authors>Henk Mollema;Rodrigo de Oliveira</Authors>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/rodri-oliveira-dev/Dapper-FluentMap</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReleaseNotes>https://github.com/rodri-oliveira-dev/Dapper-FluentMap/releases/tag/v$(PackageVersion)</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <Deterministic>true</Deterministic>

--- a/eng/validate-package-metadata.ps1
+++ b/eng/validate-package-metadata.ps1
@@ -52,7 +52,21 @@ function Get-ChildText {
   return $child.InnerText
 }
 
-function Split-MetadataList {
+function Split-Authors {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return @()
+  }
+
+  return @(
+    $Value -split '[;,]' |
+      ForEach-Object { $_.Trim() } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+}
+
+function Split-Tags {
   param([string]$Value)
 
   if ([string]::IsNullOrWhiteSpace($Value)) {
@@ -121,14 +135,14 @@ foreach ($file in $nupkgs) {
       Fail "$id must have a meaningful package description."
     }
 
-    $authors = Split-MetadataList -Value (Get-ChildText -Node $metadata -Name 'authors')
+    $authors = Split-Authors -Value (Get-ChildText -Node $metadata -Name 'authors')
     foreach ($expectedAuthor in $expectedAuthors) {
       if ($expectedAuthor -notin $authors) {
         Fail "$id authors '$($authors -join ', ')' must include '$expectedAuthor'."
       }
     }
 
-    $tags = Split-MetadataList -Value (Get-ChildText -Node $metadata -Name 'tags')
+    $tags = Split-Tags -Value (Get-ChildText -Node $metadata -Name 'tags')
     foreach ($requiredTag in $expected.RequiredTags) {
       if ($requiredTag -notin $tags) {
         Fail "$id tags are missing '$requiredTag'."

--- a/eng/validate-package-metadata.ps1
+++ b/eng/validate-package-metadata.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PackageDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$expectedRepositoryUrl = 'https://github.com/rodri-oliveira-dev/Dapper-FluentMap'
+$expectedReleaseNotesUrl = 'https://github.com/rodri-oliveira-dev/Dapper-FluentMap/releases'
+$expectedAuthors = @('Henk Mollema', 'Rodrigo de Oliveira')
+$expectedPackages = @{
+  'Dapper.FluentMap' = @{
+    Title = 'Dapper.FluentMap'
+    RequiredTags = @('dapper', 'fluent-mapping', 'mapping', 'micro-orm', 'database', 'sql', 'poco', 'fluentmap')
+  }
+  'Dapper.FluentMap.Dommel' = @{
+    Title = 'Dapper.FluentMap - Dommel Integration'
+    RequiredTags = @('dapper', 'dommel', 'fluent-mapping', 'mapping', 'crud', 'database', 'sql', 'fluentmap')
+  }
+  'Dapper.FluentMap.DependencyInjection' = @{
+    Title = 'Dapper.FluentMap - Dependency Injection'
+    RequiredTags = @('dapper', 'dependency-injection', 'di', 'fluent-mapping', 'mapping', 'database', 'fluentmap')
+  }
+  'Dapper.FluentMap.Analyzers' = @{
+    Title = 'Dapper.FluentMap Analyzers'
+    RequiredTags = @('dapper', 'roslyn', 'analyzers', 'mapping', 'diagnostics', 'fluent-mapping', 'fluentmap')
+  }
+  'Dapper.FluentMap.Generators' = @{
+    Title = 'Dapper.FluentMap Source Generators'
+    RequiredTags = @('dapper', 'roslyn', 'source-generator', 'mapping', 'code-generation', 'fluent-mapping', 'fluentmap')
+  }
+}
+
+function Fail {
+  param([string]$Message)
+  throw "NuGet package metadata validation failed: $Message"
+}
+
+function Get-ChildText {
+  param(
+    [System.Xml.XmlNode]$Node,
+    [string]$Name
+  )
+
+  $child = $Node.ChildNodes | Where-Object { $_.LocalName -eq $Name } | Select-Object -First 1
+  if ($null -eq $child) {
+    return $null
+  }
+
+  return $child.InnerText
+}
+
+function Split-MetadataList {
+  param([string]$Value)
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return @()
+  }
+
+  return @(
+    $Value -split '[;,\s]+' |
+      ForEach-Object { $_.Trim() } |
+      Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+  )
+}
+
+if (-not (Test-Path -LiteralPath $PackageDirectory -PathType Container)) {
+  Fail "Package directory '$PackageDirectory' does not exist."
+}
+
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$packageRoot = (Resolve-Path -LiteralPath $PackageDirectory).Path
+$nupkgs = @(Get-ChildItem -LiteralPath $packageRoot -File -Filter '*.nupkg' | Sort-Object Name)
+
+if ($nupkgs.Count -ne $expectedPackages.Count) {
+  Fail "Expected $($expectedPackages.Count) .nupkg files, found $($nupkgs.Count)."
+}
+
+foreach ($file in $nupkgs) {
+  $archive = [System.IO.Compression.ZipFile]::OpenRead($file.FullName)
+  try {
+    $nuspecEntries = @($archive.Entries | Where-Object { $_.FullName -like '*.nuspec' })
+    if ($nuspecEntries.Count -ne 1) {
+      Fail "$($file.Name) must contain exactly one nuspec, found $($nuspecEntries.Count)."
+    }
+
+    $stream = $nuspecEntries[0].Open()
+    try {
+      $reader = [System.IO.StreamReader]::new($stream)
+      try {
+        [xml]$nuspec = $reader.ReadToEnd()
+      }
+      finally {
+        $reader.Dispose()
+      }
+    }
+    finally {
+      $stream.Dispose()
+    }
+
+    $metadata = $nuspec.SelectSingleNode('//*[local-name()="metadata"]')
+    if ($null -eq $metadata) {
+      Fail "$($file.Name) is missing nuspec metadata."
+    }
+
+    $id = Get-ChildText -Node $metadata -Name 'id'
+    if (-not $expectedPackages.ContainsKey($id)) {
+      Fail "$($file.Name) has unexpected package ID '$id'."
+    }
+
+    $expected = $expectedPackages[$id]
+    $title = Get-ChildText -Node $metadata -Name 'title'
+    if ($title -ne $expected.Title) {
+      Fail "$id title is '$title', expected '$($expected.Title)'."
+    }
+
+    $description = Get-ChildText -Node $metadata -Name 'description'
+    if ([string]::IsNullOrWhiteSpace($description) -or $description.Length -lt 40) {
+      Fail "$id must have a meaningful package description."
+    }
+
+    $authors = Split-MetadataList -Value (Get-ChildText -Node $metadata -Name 'authors')
+    foreach ($expectedAuthor in $expectedAuthors) {
+      if ($expectedAuthor -notin $authors) {
+        Fail "$id authors '$($authors -join ', ')' must include '$expectedAuthor'."
+      }
+    }
+
+    $tags = Split-MetadataList -Value (Get-ChildText -Node $metadata -Name 'tags')
+    foreach ($requiredTag in $expected.RequiredTags) {
+      if ($requiredTag -notin $tags) {
+        Fail "$id tags are missing '$requiredTag'."
+      }
+    }
+
+    $projectUrl = Get-ChildText -Node $metadata -Name 'projectUrl'
+    if ($projectUrl -ne $expectedRepositoryUrl) {
+      Fail "$id projectUrl is '$projectUrl', expected '$expectedRepositoryUrl'."
+    }
+
+    $releaseNotes = Get-ChildText -Node $metadata -Name 'releaseNotes'
+    if ($releaseNotes -ne $expectedReleaseNotesUrl) {
+      Fail "$id releaseNotes is '$releaseNotes', expected '$expectedReleaseNotesUrl'."
+    }
+
+    $readme = Get-ChildText -Node $metadata -Name 'readme'
+    if ($readme -ne 'README.md' -or 'README.md' -notin @($archive.Entries.FullName)) {
+      Fail "$id must reference and include README.md."
+    }
+
+    $licenseNode = $metadata.ChildNodes | Where-Object { $_.LocalName -eq 'license' } | Select-Object -First 1
+    if ($null -eq $licenseNode -or $licenseNode.GetAttribute('type') -ne 'expression' -or $licenseNode.InnerText -ne 'MIT') {
+      Fail "$id must use the MIT license expression."
+    }
+
+    $repositoryNode = $metadata.ChildNodes | Where-Object { $_.LocalName -eq 'repository' } | Select-Object -First 1
+    if ($null -eq $repositoryNode -or $repositoryNode.GetAttribute('url') -ne $expectedRepositoryUrl) {
+      Fail "$id must point repository metadata to '$expectedRepositoryUrl'."
+    }
+  }
+  finally {
+    $archive.Dispose()
+  }
+}
+
+Write-Host "Validated NuGet presentation metadata for $($nupkgs.Count) packages."

--- a/src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj
+++ b/src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Roslyn analyzers for Dapper.FluentMap configuration.</Description>
+    <Title>Dapper.FluentMap Analyzers</Title>
+    <Description>Roslyn analyzers for Dapper.FluentMap that detect statically provable mapping and configuration problems at build time.</Description>
     <VersionPrefix>$(FluentMapPackageVersionPrefix)</VersionPrefix>
-    <Authors>Henk Mollema</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Dapper.FluentMap.Analyzers</PackageId>
-    <PackageTags>c#;dapper;mapping;fluentmap;roslyn;analyzers</PackageTags>
+    <PackageTags>dapper;roslyn;analyzers;mapping;diagnostics;fluent-mapping;fluentmap</PackageTags>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>

--- a/src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj
+++ b/src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Dependency injection integration for Dapper.FluentMap.</Description>
+    <Title>Dapper.FluentMap - Dependency Injection</Title>
+    <Description>Microsoft.Extensions.DependencyInjection integration for Dapper.FluentMap isolated configuration, registration, and mapping services.</Description>
     <Copyright>Copyright © Henk Mollema 2014</Copyright>
     <VersionPrefix>$(FluentMapPackageVersionPrefix)</VersionPrefix>
-    <Authors>Henk Mollema</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageId>Dapper.FluentMap.DependencyInjection</PackageId>
-    <PackageTags>c#;dapper;mapping;fluentmap;dependency-injection</PackageTags>
+    <PackageTags>dapper;dependency-injection;di;fluent-mapping;mapping;database;fluentmap</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
+++ b/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Dapper.FluentMap extension for Dommel support.</Description>
+    <Title>Dapper.FluentMap - Dommel Integration</Title>
+    <Description>Dommel integration for Dapper.FluentMap, providing fluent table, key, generated-column, and persistence metadata mappings.</Description>
     <Copyright>Copyright © Henk Mollema 2014</Copyright>
     <VersionPrefix>$(FluentMapPackageVersionPrefix)</VersionPrefix>
-    <Authors>Henk Mollema</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageTags>dapper;fluentmap;dommel</PackageTags>
+    <PackageTags>dapper;dommel;fluent-mapping;mapping;crud;database;sql;fluentmap</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion Condition="'$(EnableFluentMapHistoricalApiCompatValidation)' == 'true'">2.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>

--- a/src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj
+++ b/src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Source generators for Dapper.FluentMap mapping registration.</Description>
+    <Title>Dapper.FluentMap Source Generators</Title>
+    <Description>Roslyn source generators for Dapper.FluentMap build-time map registration and supported generated materializers.</Description>
     <VersionPrefix>$(FluentMapPackageVersionPrefix)</VersionPrefix>
-    <Authors>Henk Mollema</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Dapper.FluentMap.Generators</PackageId>
-    <PackageTags>c#;dapper;mapping;fluentmap;roslyn;source-generator</PackageTags>
+    <PackageTags>dapper;roslyn;source-generator;mapping;code-generation;fluent-mapping;fluentmap</PackageTags>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeSymbols>false</IncludeSymbols>
   </PropertyGroup>

--- a/src/Dapper.FluentMap/Dapper.FluentMap.csproj
+++ b/src/Dapper.FluentMap/Dapper.FluentMap.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Description>Simple API to fluently map POCO properties to database columns when using Dapper.</Description>
+    <Title>Dapper.FluentMap</Title>
+    <Description>Fluent mapping for Dapper, including explicit property-to-column maps, conventions, immutable object materialization, profiles, diagnostics, and opt-in modern mapping capabilities.</Description>
     <Copyright>Copyright © Henk Mollema 2014</Copyright>
     <VersionPrefix>$(FluentMapPackageVersionPrefix)</VersionPrefix>
-    <Authors>Henk Mollema</Authors>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageTags>c#;dapper;mapping;fluentmap</PackageTags>
+    <PackageTags>dapper;fluent-mapping;mapping;micro-orm;database;sql;poco;fluentmap</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion Condition="'$(EnableFluentMapHistoricalApiCompatValidation)' == 'true'">2.0.0</PackageValidationBaselineVersion>
   </PropertyGroup>


### PR DESCRIPTION
## Summary

Refreshes NuGet package metadata for the current Dapper.FluentMap stewardship while preserving the project's original authorship history.

### Package metadata
- centralizes package authors as `Henk Mollema;Rodrigo de Oliveira`;
- keeps the existing MIT license, repository/project URLs, README packaging, symbols and deterministic build metadata;
- adds a stable GitHub Releases URL as `PackageReleaseNotes`;
- adds explicit package titles for all five packages;
- modernizes package descriptions to reflect the 3.0 feature set and positioning;
- improves discovery tags for core, Dommel, dependency injection, analyzers and source generators;
- intentionally does **not** add a package icon yet.

### Metadata protection
- adds `eng/validate-package-metadata.ps1` to inspect the generated `.nupkg` nuspecs;
- CI now verifies current/original authorship, titles, meaningful descriptions, required tags, repository/project URLs, release notes URL, MIT license and packaged README for all five packages.

## Ownership note
NuGet.org Gallery ownership is account-level and is not controlled by `.nuspec`/MSBuild package metadata. This PR makes Rodrigo de Oliveira visible as a current package author/maintainer while preserving Henk Mollema's original authorship. The NuGet.org owner assignment itself must still be configured on the package/account side.

## Packages
- `Dapper.FluentMap`
- `Dapper.FluentMap.Dommel`
- `Dapper.FluentMap.DependencyInjection`
- `Dapper.FluentMap.Analyzers`
- `Dapper.FluentMap.Generators`
