### PR TITLE
fix(release): setup .NET in publish jobs without checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
-          global-json-file: global.json
+          dotnet-version: '10.0.x'
 
       - name: Download release package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -332,7 +332,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
-          global-json-file: global.json
+          dotnet-version: '10.0.x'
 
       - name: Download release package
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## Summary

Fixes the failure observed in release run `34225133102`.

## Root cause

The `Publish to NuGet.org` and `Publish to GitHub Packages` jobs run on fresh GitHub-hosted runners and intentionally do not check out the repository. Both jobs configured `actions/setup-dotnet` with `global-json-file: global.json`, so the action failed immediately because `global.json` was not present in the empty workspace.

The build/package job succeeded because it performs checkout before `setup-dotnet`.

## Fix

- keeps the privileged publish jobs checkout-free;
- changes their SDK setup to `dotnet-version: '10.0.x'`;
- preserves `global-json-file: global.json` in the build job, where the repository is checked out;
- aligns the publish-job setup with the staged release pattern used by `complexity-analyzers`.

Only `.github/workflows/release.yml` changes: 2 additions / 2 deletions.

## Important retry note

The failed run already created tag `v3.0.0-rc.1` at commit `31ed47bb16581fc1aef271b7db8227c96b6add01`, but neither NuGet.org nor GitHub Packages was reached. After this PR is merged, `master` will point to a newer commit, so starting a fresh `3.0.0-rc.1` release will hit the workflow's tag/commit immutability guard unless the unpublished RC tag is deliberately moved/recreated or a new version (for example `3.0.0-rc.2`) is chosen.
