### PR TITLE
fix(release): preflight tag and NuGet version availability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Validate release version
+      - name: Validate release version and availability
         id: version
         shell: bash
         env:
@@ -84,15 +84,63 @@ jobs:
             is_prerelease=true
           fi
 
+          echo "Checking whether release tag '$release_tag' already exists..."
           git fetch --tags --force
           if git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
             tag_sha="$(git rev-list -n 1 "$release_tag")"
-            if [[ "$tag_sha" != "$GITHUB_SHA" ]]; then
-              echo "::error::Tag '$release_tag' already exists and points to $tag_sha instead of $GITHUB_SHA."
+            echo "::error::Release tag '$release_tag' already exists and points to $tag_sha. Choose a new version before building."
+            exit 1
+          fi
+
+          package_ids=(
+            'Dapper.FluentMap'
+            'Dapper.FluentMap.Dommel'
+            'Dapper.FluentMap.DependencyInjection'
+            'Dapper.FluentMap.Analyzers'
+            'Dapper.FluentMap.Generators'
+          )
+          version_lower="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')"
+          published_packages=()
+
+          echo "Checking NuGet.org for version '$VERSION' before build..."
+          for package_id in "${package_ids[@]}"; do
+            package_id_lower="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
+            package_url="https://api.nuget.org/v3-flatcontainer/$package_id_lower/$version_lower/$package_id_lower.$version_lower.nupkg"
+
+            if ! http_status="$(curl \
+              --silent \
+              --show-error \
+              --location \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              "$package_url")"; then
+              echo "::error::Unable to verify NuGet.org availability for $package_id $VERSION. Failing closed before build."
               exit 1
             fi
 
-            echo "Tag '$release_tag' already exists on the validated commit; this run can be safely retried."
+            case "$http_status" in
+              200)
+                echo "::error::$package_id $VERSION is already published on NuGet.org."
+                published_packages+=("$package_id")
+                ;;
+              404)
+                echo "$package_id $VERSION is available on NuGet.org."
+                ;;
+              *)
+                echo "::error::Unexpected NuGet.org response $http_status while checking $package_id $VERSION. Failing closed before build."
+                exit 1
+                ;;
+            esac
+          done
+
+          if (( ${#published_packages[@]} > 0 )); then
+            echo "::error::Release version '$VERSION' is already published for: ${published_packages[*]}. Choose a new version."
+            exit 1
           fi
 
           echo "package_version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -100,6 +148,7 @@ jobs:
           echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
           echo "Release version: $VERSION"
           echo "Release tag: $release_tag"
+          echo "Preflight passed: tag is unused and the version is unpublished for all FluentMap NuGet packages."
 
       - name: Show .NET info
         run: dotnet --info

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,6 @@
 <Project>
   <Target Name="BlockUnsafeFluentMapPackageVersions" BeforeTargets="Pack" Condition="'$(IsPackable)' != 'false'">
     <Error Condition="'$(PackageVersion)' == '2.0.0' or ('$(PackageVersion)' == '' and '$(Version)' == '2.0.0')"
-           Text="Version 2.0.0 already exists for historical FluentMap package IDs and must not be produced by this fork." />
-    <Error Condition="'$(PackageVersion)' == '3.0.0' or ('$(PackageVersion)' == '' and '$(Version)' == '3.0.0')"
-           Text="Stable version 3.0.0 is disabled during the 3.0.0-rc.1 release freeze. Use the local default 3.0.0-dev or an explicit prerelease version such as 3.0.0-rc.1." />
+           Text="Version 2.0.0 already exists for historical FluentMap package IDs and must not be produced by this repository." />
   </Target>
 </Project>


### PR DESCRIPTION
## Summary

Makes the release workflow accept the SemVer provided through `workflow_dispatch` (major 3+) without the obsolete hardcoded `3.0.0` freeze, and moves release uniqueness checks ahead of build work.

## Changes

- removes the temporary `3.0.0-rc.1` stable-release freeze from `Directory.Build.targets`;
- preserves the historical `2.0.0` safety guard;
- extends the initial release validation to fail before restore/build when `v<version>` already exists;
- checks all five FluentMap package IDs against the NuGet.org V3 flat-container endpoint before build;
- fails if the requested version is already published for **any** target package;
- treats `404` as available and unexpected/network responses as fail-closed;
- keeps existing SemVer validation, `master` restriction, major-version guard and prerelease detection.

## Target packages checked

- `Dapper.FluentMap`
- `Dapper.FluentMap.Dommel`
- `Dapper.FluentMap.DependencyInjection`
- `Dapper.FluentMap.Analyzers`
- `Dapper.FluentMap.Generators`

## Resulting release behavior

For an input such as `3.0.0`, the workflow now performs this preflight before build:

1. validate SemVer/branch/major version;
2. reject if tag `v3.0.0` already exists;
3. reject if `3.0.0` is already published on NuGet.org for any target package;
4. only when both checks are clear, continue to restore, audit, build, test and pack.

This intentionally makes a package version single-use: if a previous attempt has already created the tag or published any package under that version, a new release must use a new version instead of rebuilding under the same identity.