### PR TITLE
fix(release): compensate partial publications on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -492,3 +492,56 @@ jobs:
             "${assets[@]}" \
             --repo "$GH_REPO" \
             "${release_args[@]}"
+
+  rollback:
+    name: Roll back failed release
+    if: >-
+      ${{ always() &&
+          needs.build-and-pack.result == 'success' &&
+          (needs.ensure-release-tag.result == 'failure' ||
+           needs.publish-nuget.result == 'failure' ||
+           needs.publish-github-packages.result == 'failure' ||
+           needs.github-release.result == 'failure') }}
+    needs:
+      - build-and-pack
+      - ensure-release-tag
+      - publish-nuget
+      - publish-github-packages
+      - github-release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Checkout rollback tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: Exchange GitHub OIDC token for rollback NuGet API key
+        id: rollback-nuget-login
+        continue-on-error: true
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: "${{ vars.NUGET_USER }}"
+
+      - name: Compensate failed release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NUGET_API_KEY: ${{ steps.rollback-nuget-login.outputs.NUGET_API_KEY }}
+          PACKAGE_VERSION: ${{ needs.build-and-pack.outputs.package-version }}
+          RELEASE_TAG: ${{ needs.build-and-pack.outputs.release-tag }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./eng/rollback-release.ps1 `
+            -Version $env:PACKAGE_VERSION `
+            -ReleaseTag $env:RELEASE_TAG `
+            -Repository '${{ github.repository }}' `
+            -RepositoryOwner '${{ github.repository_owner }}' `
+            -GitHubToken $env:GH_TOKEN `
+            -NuGetApiKey $env:NUGET_API_KEY

--- a/eng/rollback-release.ps1
+++ b/eng/rollback-release.ps1
@@ -1,0 +1,194 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseTag,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepositoryOwner,
+
+    [Parameter(Mandatory = $true)]
+    [string]$GitHubToken,
+
+    [string]$NuGetApiKey
+)
+
+$ErrorActionPreference = 'Stop'
+
+$packageIds = @(
+    'Dapper.FluentMap',
+    'Dapper.FluentMap.Dommel',
+    'Dapper.FluentMap.DependencyInjection',
+    'Dapper.FluentMap.Analyzers',
+    'Dapper.FluentMap.Generators'
+)
+
+$failures = [System.Collections.Generic.List[string]]::new()
+
+function Add-RollbackFailure {
+    param([string]$Message)
+
+    $failures.Add($Message)
+    Write-Error $Message -ErrorAction Continue
+}
+
+function Invoke-GitHubRequest {
+    param(
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('GET', 'DELETE')]
+        [string]$Method,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Uri
+    )
+
+    $headers = @{
+        Authorization = "Bearer $GitHubToken"
+        Accept = 'application/vnd.github+json'
+        'X-GitHub-Api-Version' = '2022-11-28'
+        'User-Agent' = 'Dapper-FluentMap-release-rollback'
+    }
+
+    try {
+        return Invoke-WebRequest `
+            -Uri $Uri `
+            -Method $Method `
+            -Headers $headers `
+            -SkipHttpErrorCheck
+    }
+    catch {
+        Add-RollbackFailure "GitHub rollback request failed for $Method $Uri`: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+Write-Host "Starting compensating rollback for $ReleaseTag ($Version)."
+Write-Host 'NuGet.org cannot permanently delete a published version; rollback unlists versions that were created before the release failed.'
+
+# NuGet.org compensation: unlist any target package version that exists.
+if ([string]::IsNullOrWhiteSpace($NuGetApiKey)) {
+    Add-RollbackFailure 'No temporary NuGet API key was available for rollback. Ensure the Trusted Publishing policy grants Unlist/relist scope.'
+}
+else {
+    foreach ($packageId in $packageIds) {
+        $escapedId = [System.Uri]::EscapeDataString($packageId)
+        $escapedVersion = [System.Uri]::EscapeDataString($Version)
+        $uri = "https://www.nuget.org/api/v2/package/$escapedId/$escapedVersion"
+
+        try {
+            $response = Invoke-WebRequest `
+                -Uri $uri `
+                -Method Delete `
+                -Headers @{ 'X-NuGet-ApiKey' = $NuGetApiKey } `
+                -SkipHttpErrorCheck
+
+            switch ([int]$response.StatusCode) {
+                204 { Write-Host "NuGet.org: unlisted $packageId $Version." }
+                404 { Write-Host "NuGet.org: $packageId $Version was not published; nothing to unlist." }
+                default {
+                    Add-RollbackFailure "NuGet.org rollback for $packageId $Version returned HTTP $([int]$response.StatusCode)."
+                }
+            }
+        }
+        catch {
+            Add-RollbackFailure "NuGet.org rollback failed for $packageId $Version`: $($_.Exception.Message)"
+        }
+    }
+}
+
+# GitHub Packages compensation: delete this version from each NuGet package.
+foreach ($packageId in $packageIds) {
+    $escapedPackageId = [System.Uri]::EscapeDataString($packageId)
+    $versionIds = [System.Collections.Generic.List[long]]::new()
+    $page = 1
+
+    while ($true) {
+        $listUri = "https://api.github.com/users/$RepositoryOwner/packages/nuget/$escapedPackageId/versions?per_page=100&page=$page"
+        $response = Invoke-GitHubRequest -Method GET -Uri $listUri
+        if ($null -eq $response) {
+            break
+        }
+
+        $status = [int]$response.StatusCode
+        if ($status -eq 404) {
+            Write-Host "GitHub Packages: $packageId does not exist; nothing to delete."
+            break
+        }
+
+        if ($status -ne 200) {
+            Add-RollbackFailure "GitHub Packages lookup for $packageId returned HTTP $status."
+            break
+        }
+
+        $versions = @($response.Content | ConvertFrom-Json)
+        foreach ($packageVersion in $versions) {
+            if ([string]$packageVersion.name -eq $Version) {
+                $versionIds.Add([long]$packageVersion.id)
+            }
+        }
+
+        if ($versions.Count -lt 100) {
+            break
+        }
+
+        $page++
+    }
+
+    foreach ($versionId in $versionIds) {
+        $deleteUri = "https://api.github.com/users/$RepositoryOwner/packages/nuget/$escapedPackageId/versions/$versionId"
+        $deleteResponse = Invoke-GitHubRequest -Method DELETE -Uri $deleteUri
+        if ($null -eq $deleteResponse) {
+            continue
+        }
+
+        $deleteStatus = [int]$deleteResponse.StatusCode
+        if ($deleteStatus -in @(204, 404)) {
+            Write-Host "GitHub Packages: deleted $packageId $Version (version id $versionId)."
+        }
+        else {
+            Add-RollbackFailure "GitHub Packages deletion for $packageId $Version returned HTTP $deleteStatus."
+        }
+    }
+}
+
+# Remove a partially-created GitHub Release, if any.
+$escapedTag = [System.Uri]::EscapeDataString($ReleaseTag)
+$releaseLookup = Invoke-GitHubRequest -Method GET -Uri "https://api.github.com/repos/$Repository/releases/tags/$escapedTag"
+if ($null -ne $releaseLookup) {
+    $releaseStatus = [int]$releaseLookup.StatusCode
+    if ($releaseStatus -eq 200) {
+        $release = $releaseLookup.Content | ConvertFrom-Json
+        $releaseDelete = Invoke-GitHubRequest -Method DELETE -Uri "https://api.github.com/repos/$Repository/releases/$($release.id)"
+        if ($null -ne $releaseDelete -and [int]$releaseDelete.StatusCode -notin @(204, 404)) {
+            Add-RollbackFailure "GitHub Release deletion for $ReleaseTag returned HTTP $([int]$releaseDelete.StatusCode)."
+        }
+        else {
+            Write-Host "GitHub Release: removed $ReleaseTag."
+        }
+    }
+    elseif ($releaseStatus -ne 404) {
+        Add-RollbackFailure "GitHub Release lookup for $ReleaseTag returned HTTP $releaseStatus."
+    }
+}
+
+# Remove the release tag last, after registry compensation has been attempted.
+$tagDelete = Invoke-GitHubRequest -Method DELETE -Uri "https://api.github.com/repos/$Repository/git/refs/tags/$escapedTag"
+if ($null -ne $tagDelete) {
+    $tagStatus = [int]$tagDelete.StatusCode
+    if ($tagStatus -in @(204, 404, 422)) {
+        Write-Host "Git tag: removed or already absent: $ReleaseTag."
+    }
+    else {
+        Add-RollbackFailure "Git tag deletion for $ReleaseTag returned HTTP $tagStatus."
+    }
+}
+
+if ($failures.Count -gt 0) {
+    throw "Release rollback completed with $($failures.Count) compensation error(s). Review the rollback log before starting another release."
+}
+
+Write-Host "Compensating rollback completed for $ReleaseTag."


### PR DESCRIPTION
## Summary

Adds a compensating rollback stage to the protected release workflow so a failed publication does not leave the Git tag, GitHub Release, and GitHub Packages versions behind, and attempts to unlist NuGet.org versions that were already pushed before the failure.

## Root cause of run 34234097570

The workflow itself authenticated correctly and the package artifacts/checksums were valid. NuGet.org accepted:

- `Dapper.FluentMap 3.0.0`
- `Dapper.FluentMap.Dommel 3.0.0`

Publication then failed on `Dapper.FluentMap.DependencyInjection 3.0.0` with HTTP 409:

> This package ID has been reserved. Please request access to upload to this reserved namespace from the owner of the reserved prefix, or re-upload the package with a different ID.

This is a NuGet.org package ID prefix reservation issue, not an OIDC/Trusted Publishing failure. `Dapper.FluentMap` and `Dapper.FluentMap.Dommel` are historical package IDs and can receive new versions through their existing ownership. The three new package IDs under the `Dapper.*` namespace do not automatically inherit that right and require prefix delegation/authorization from the reserved-prefix owner or different package IDs.

The parallel GitHub Packages job succeeded, so the failed run left a partial release state.

## Rollback behavior

When build/pack succeeds but a later release stage fails, a new `Roll back failed release` job runs with `always()` and attempts all compensating actions before reporting rollback errors:

1. unlist the requested version from NuGet.org for any target package that was already published;
2. delete the requested version from all five GitHub Packages packages;
3. delete a partially created GitHub Release, if present;
4. delete the release tag last.

Rollback is implemented in `eng/rollback-release.ps1` and keeps cleanup logic out of the workflow YAML.

## Important NuGet limitation

NuGet.org does not permit permanent deletion of published package versions. The compensation operation is therefore an **unlist**, not a true delete. An unlisted exact version remains restorable and that version number must not be reused.

For automatic NuGet compensation to work, the existing Trusted Publishing policy for `.github/workflows/release.yml` / environment `release` must also grant **Unlist or relist package versions** in addition to push permission.

## Current run

This change protects future release attempts. It cannot retroactively execute against run `34234097570`; its existing partial NuGet/GitHub Packages state must be handled separately before choosing the next release version.
