### PR TITLE
fix(release): add one-off recovery for missing NuGet 3.0.0 packages

### DIFF
--- a/.github/workflows/release-recovery-missing-nuget.yml
+++ b/.github/workflows/release-recovery-missing-nuget.yml
@@ -1,0 +1,299 @@
+name: Recovery - Publish missing NuGet 3.0.0 packages
+
+run-name: "Recover missing NuGet 3.0.0 packages"
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: "Type PUBLISH-MISSING-3.0.0 to run the one-off recovery"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-recovery-3.0.0
+  cancel-in-progress: false
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
+  DOTNET_NOLOGO: "true"
+  CI: "true"
+  RECOVERY_VERSION: "3.0.0"
+  # This is the exact commit that produced the partially published 3.0.0 artifacts
+  # in release run 34234097570. Recovery packages must come from the same source.
+  RECOVERY_COMMIT: "758318cce5fc3644a93916978118e24fb7fadb59"
+
+jobs:
+  recover-missing-nuget-packages:
+    name: Publish only missing NuGet.org packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Validate recovery confirmation
+        shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
+            echo "::error::The recovery workflow must be started from master. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
+          if [[ "$CONFIRMATION" != "PUBLISH-MISSING-3.0.0" ]]; then
+            echo "::error::Recovery confirmation did not match PUBLISH-MISSING-3.0.0."
+            exit 1
+          fi
+
+      - name: Checkout original 3.0.0 release commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ env.RECOVERY_COMMIT }}
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          global-json-file: global.json
+
+      - name: Detect packages still missing from NuGet.org
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          nuget_status() {
+            local package_id="$1"
+            local package_id_lower
+            package_id_lower="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
+            local version_lower
+            version_lower="$(printf '%s' "$RECOVERY_VERSION" | tr '[:upper:]' '[:lower:]')"
+            local package_url="https://api.nuget.org/v3-flatcontainer/$package_id_lower/$version_lower/$package_id_lower.$version_lower.nupkg"
+
+            curl \
+              --silent \
+              --show-error \
+              --location \
+              --retry 3 \
+              --retry-delay 2 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              "$package_url"
+          }
+
+          # These two packages were successfully published by run 34234097570.
+          for package_id in 'Dapper.FluentMap' 'Dapper.FluentMap.Dommel'; do
+            status="$(nuget_status "$package_id")"
+            if [[ "$status" != "200" ]]; then
+              echo "::error::Expected $package_id $RECOVERY_VERSION to already exist on NuGet.org, but NuGet returned HTTP $status. Refusing recovery."
+              exit 1
+            fi
+            echo "$package_id $RECOVERY_VERSION already exists as expected."
+          done
+
+          targets=(
+            'Dapper.FluentMap.DependencyInjection'
+            'Dapper.FluentMap.Analyzers'
+            'Dapper.FluentMap.Generators'
+          )
+          missing=()
+
+          for package_id in "${targets[@]}"; do
+            status="$(nuget_status "$package_id")"
+            case "$status" in
+              200)
+                echo "$package_id $RECOVERY_VERSION already exists; it will be skipped."
+                ;;
+              404)
+                echo "$package_id $RECOVERY_VERSION is missing and will be published."
+                missing+=("$package_id")
+                ;;
+              *)
+                echo "::error::Unexpected NuGet.org response HTTP $status while checking $package_id $RECOVERY_VERSION. Failing closed."
+                exit 1
+                ;;
+            esac
+          done
+
+          if (( ${#missing[@]} == 0 )); then
+            echo "has_missing=false" >> "$GITHUB_OUTPUT"
+            echo "package_ids=" >> "$GITHUB_OUTPUT"
+            echo "All recovery package IDs already exist on NuGet.org; nothing to publish."
+            exit 0
+          fi
+
+          package_ids="$(IFS=';'; echo "${missing[*]}")"
+          echo "has_missing=true" >> "$GITHUB_OUTPUT"
+          echo "package_ids=$package_ids" >> "$GITHUB_OUTPUT"
+          echo "Missing packages: $package_ids"
+
+      - name: Restore
+        if: steps.preflight.outputs.has_missing == 'true'
+        run: dotnet restore ./Dapper.FluentMap.sln
+
+      - name: Build original 3.0.0 release source
+        if: steps.preflight.outputs.has_missing == 'true'
+        run: >-
+          dotnet build ./Dapper.FluentMap.sln
+          --configuration Release
+          --no-restore
+          -p:Version=${RECOVERY_VERSION}
+          -p:RepositoryCommit=${RECOVERY_COMMIT}
+          -p:RepositoryBranch=refs/heads/master
+          -p:ContinuousIntegrationBuild=true
+
+      - name: Run tests
+        if: steps.preflight.outputs.has_missing == 'true'
+        run: dotnet test ./Dapper.FluentMap.sln --configuration Release --no-build --no-restore
+
+      - name: Pack recovery packages
+        if: steps.preflight.outputs.has_missing == 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path './artifacts/packages' | Out-Null
+
+          $projects = @(
+            './src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj',
+            './src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj',
+            './src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj'
+          )
+
+          foreach ($project in $projects) {
+            dotnet pack $project `
+              --configuration Release `
+              --no-build `
+              --no-restore `
+              --output './artifacts/packages' `
+              -p:Version=$env:RECOVERY_VERSION `
+              -p:RepositoryCommit=$env:RECOVERY_COMMIT `
+              -p:RepositoryBranch='refs/heads/master' `
+              -p:ContinuousIntegrationBuild=true
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "Packing failed for $project."
+            }
+          }
+
+          $expected = @(
+            'Dapper.FluentMap.DependencyInjection.3.0.0.nupkg',
+            'Dapper.FluentMap.Analyzers.3.0.0.nupkg',
+            'Dapper.FluentMap.Generators.3.0.0.nupkg'
+          )
+
+          foreach ($file in $expected) {
+            $path = Join-Path './artifacts/packages' $file
+            if (-not (Test-Path -LiteralPath $path)) {
+              throw "Expected recovery package '$file' was not produced."
+            }
+          }
+
+      - name: Exchange GitHub OIDC token for temporary NuGet API key
+        if: steps.preflight.outputs.has_missing == 'true'
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: "${{ vars.NUGET_USER }}"
+
+      - name: Publish only packages that are still missing
+        if: steps.preflight.outputs.has_missing == 'true'
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          PACKAGE_IDS: ${{ steps.preflight.outputs.package_ids }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $packageIds = $env:PACKAGE_IDS.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)
+
+          foreach ($packageId in $packageIds) {
+            $idLower = $packageId.ToLowerInvariant()
+            $versionLower = $env:RECOVERY_VERSION.ToLowerInvariant()
+            $url = "https://api.nuget.org/v3-flatcontainer/$idLower/$versionLower/$idLower.$versionLower.nupkg"
+
+            $status = (& curl `
+              --silent `
+              --show-error `
+              --location `
+              --retry 3 `
+              --retry-delay 2 `
+              --retry-all-errors `
+              --connect-timeout 10 `
+              --max-time 30 `
+              --output /dev/null `
+              --write-out '%{http_code}' `
+              $url).Trim()
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "Unable to re-check NuGet.org before publishing $packageId $env:RECOVERY_VERSION."
+            }
+
+            if ($status -eq '200') {
+              Write-Host "$packageId $env:RECOVERY_VERSION appeared on NuGet.org after preflight; skipping it."
+              continue
+            }
+
+            if ($status -ne '404') {
+              throw "Unexpected NuGet.org response HTTP $status for $packageId $env:RECOVERY_VERSION."
+            }
+
+            $package = "./artifacts/packages/$packageId.$env:RECOVERY_VERSION.nupkg"
+            dotnet nuget push $package `
+              --source 'https://api.nuget.org/v3/index.json' `
+              --api-key $env:NUGET_API_KEY
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "Recovery publication failed for $packageId. If NuGet reports a reserved package ID/prefix, the NuGet account still needs authorization for the reserved Dapper prefix before this recovery can succeed."
+            }
+          }
+
+      - name: Verify recovery result
+        if: steps.preflight.outputs.has_missing == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for package_id in \
+            'Dapper.FluentMap.DependencyInjection' \
+            'Dapper.FluentMap.Analyzers' \
+            'Dapper.FluentMap.Generators'; do
+            package_id_lower="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
+            version_lower="$(printf '%s' "$RECOVERY_VERSION" | tr '[:upper:]' '[:lower:]')"
+            package_url="https://api.nuget.org/v3-flatcontainer/$package_id_lower/$version_lower/$package_id_lower.$version_lower.nupkg"
+
+            status="$(curl \
+              --silent \
+              --show-error \
+              --location \
+              --retry 6 \
+              --retry-delay 5 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 30 \
+              --output /dev/null \
+              --write-out '%{http_code}' \
+              "$package_url")"
+
+            if [[ "$status" != "200" ]]; then
+              echo "::error::$package_id $RECOVERY_VERSION is not visible on NuGet.org after recovery (HTTP $status)."
+              exit 1
+            fi
+
+            echo "$package_id $RECOVERY_VERSION is available on NuGet.org."
+          done
+
+          echo "Recovery completed: all three previously missing 3.0.0 package IDs are now published on NuGet.org."


### PR DESCRIPTION
## Summary

Adds a one-off recovery workflow for the partial `3.0.0` NuGet.org release left by run `34234097570` and detected again by run `34236515351`.

## Why this is needed

Run `34236515351` correctly stopped before build because NuGet.org already contains:

- `Dapper.FluentMap 3.0.0`
- `Dapper.FluentMap.Dommel 3.0.0`

while these three package IDs are still missing:

- `Dapper.FluentMap.DependencyInjection 3.0.0`
- `Dapper.FluentMap.Analyzers 3.0.0`
- `Dapper.FluentMap.Generators 3.0.0`

The normal release workflow intentionally treats a version as single-use and therefore cannot be used to finish this partial release.

## Recovery workflow

Adds `.github/workflows/release-recovery-missing-nuget.yml` with deliberately narrow behavior:

- only handles version `3.0.0`;
- requires the explicit confirmation `PUBLISH-MISSING-3.0.0`;
- must be dispatched from `master`;
- checks out exact commit `758318cce5fc3644a93916978118e24fb7fadb59`, which produced the original partially published `3.0.0` artifacts;
- verifies Core and Dommel `3.0.0` already exist on NuGet.org;
- detects which of DI, Analyzers, and Generators are still missing;
- builds/tests the original release commit;
- packs the three recovery projects;
- obtains a temporary NuGet API key through Trusted Publishing/OIDC;
- re-checks each Package ID immediately before push and publishes only versions still returning `404`;
- can be safely re-run: packages that have appeared since the previous attempt are skipped;
- verifies all three target IDs are visible on NuGet.org at the end.

It intentionally does **not** touch tags, GitHub Releases, or GitHub Packages. This workflow exists only to repair the current NuGet.org partial publication.

## NuGet prerequisite

The previous `409` on `Dapper.FluentMap.DependencyInjection` was caused by NuGet.org reserved-prefix authorization, not by Trusted Publishing. The recovery workflow will still fail until the `rodri-oliveira-dev` NuGet account is authorized to create the new `Dapper.FluentMap.*` package IDs under the reserved `Dapper` prefix.

Because Trusted Publishing matches the workflow filename, NuGet.org also needs a temporary policy for:

- repository: `rodri-oliveira-dev/Dapper-FluentMap`
- workflow: `release-recovery-missing-nuget.yml`
- environment: `release`
- packages: the three recovery Package IDs
- scope: push new packages and package versions

That temporary policy can be removed after recovery succeeds.