### PR TITLE
build(deps): improve Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,29 @@ updates:
       time: "09:00"
       timezone: "America/Sao_Paulo"
     open-pull-requests-limit: 5
+    groups:
+      github-actions-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:15"
+      timezone: "America/Sao_Paulo"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "build"
+      include: "scope"
 
   - package-ecosystem: "nuget"
     directory: "/"
@@ -19,6 +42,16 @@ updates:
     open-pull-requests-limit: 5
     groups:
       dotnet-minor-patch:
+        applies-to: "version-updates"
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"
+      dotnet-security:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "build"
+      include: "scope"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  repository-configuration:
+    name: Repository configuration
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
+
+      - name: Install configuration validator
+        run: python3 -m pip install --disable-pip-version-check check-jsonschema==0.38.0
+
+      - name: Validate GitHub workflows
+        run: check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml
+
+      - name: Validate Dependabot configuration
+        run: check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
+
   compatibility:
     name: Compatibility (${{ matrix.dapper-lane }}, Dapper ${{ matrix.dapper-version }})
     runs-on: ubuntu-latest
@@ -219,6 +241,7 @@ jobs:
     timeout-minutes: 5
     if: ${{ always() }}
     needs:
+      - repository-configuration
       - compatibility
       - roslyn-components
       - pack
@@ -227,11 +250,13 @@ jobs:
       - name: Verify required jobs
         shell: bash
         run: |
+          echo "repository-configuration=${{ needs.repository-configuration.result }}"
           echo "compatibility=${{ needs.compatibility.result }}"
           echo "roslyn-components=${{ needs.roslyn-components.result }}"
           echo "pack=${{ needs.pack.result }}"
 
-          if [[ "${{ needs.compatibility.result }}" != "success" || \
+          if [[ "${{ needs.repository-configuration.result }}" != "success" || \
+                "${{ needs.compatibility.result }}" != "success" || \
                 "${{ needs.roslyn-components.result }}" != "success" || \
                 "${{ needs.pack.result }}" != "success" ]]; then
             echo "One or more required CI jobs did not complete successfully."


### PR DESCRIPTION
## Summary

Improves Dependabot maintenance and strengthens PR validation for repository configuration changes.

## Changes

### Dependabot
- group GitHub Actions minor/patch version updates
- keep GitHub Actions major updates as individual PRs
- monitor the .NET SDK declared in `global.json` via `dotnet-sdk`
- explicitly scope the existing NuGet minor/patch group to version updates
- group NuGet security updates separately
- standardize Dependabot commit messages as `build(deps): ...`
- preserve the existing weekly Monday schedule and São Paulo timezone, staggering checks at 09:00, 09:15, and 09:30

### PR CI
- add a lightweight `Repository configuration` job
- validate every `.github/workflows/*.yml` file against the vendored GitHub Workflows schema
- validate `.github/dependabot.yml` against the vendored Dependabot schema
- pin `check-jsonschema` to version `0.38.0`
- make `Repository configuration` a required dependency of `CI Gate`

## Rationale

Low-risk dependency maintenance remains consolidated while major upgrades stay isolated for review. The CI now also validates repository configuration directly, preventing a PR that changes only GitHub/Dependabot YAML from going green based solely on .NET build and package tests.

## Validation

- `dotnet-sdk` is a supported Dependabot package ecosystem
- `applies-to: security-updates` is supported for Dependabot groups
- configuration validation uses vendored schemas from `check-jsonschema`
- `CI Gate` fails if repository configuration validation fails
