### PR TITLE
docs: add project badges to READMEs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-sonarscanner": {
+      "version": "11.3.0",
+      "commands": [
+        "dotnet-sonarscanner"
+      ]
+    },
+    "dotnet-coverage": {
+      "version": "18.11.0",
+      "commands": [
+        "dotnet-coverage"
+      ]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,7 +305,7 @@ jobs:
           /d:sonar.host.url="https://sonarcloud.io"
           /d:sonar.projectBaseDir="${GITHUB_WORKSPACE}"
           /d:sonar.cs.vscoveragexml.reportsPaths="artifacts/coverage/sonar/coverage.xml"
-          /d:sonar.exclusions="benchmarks/**,test/Dapper.FluentMap.AotSmoke/**,eng/consumer-smoke/**,**/bin/**,**/obj/**,**/*.g.cs,**/*.generated.cs"
+          /d:sonar.exclusions="test/**,benchmarks/**,eng/consumer-smoke/**,**/bin/**,**/obj/**,**/*.g.cs,**/*.generated.cs"
           /d:sonar.coverage.exclusions="test/**,benchmarks/**,eng/consumer-smoke/**,**/*.g.cs,**/*.generated.cs"
           /d:sonar.qualitygate.wait=true
           /d:sonar.qualitygate.timeout=300

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,7 @@ jobs:
       - repository-configuration
       - compatibility
       - roslyn-components
-    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ vars.SONAR_CI_ENABLED == 'true' && ((github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch') }}
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,12 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: "true"
+  DOTNET_COVERAGE_NOLOGO: "true"
+  DOTNET_COVERAGE_TELEMETRY_OPTOUT: "true"
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
   CI: "true"
 
@@ -241,6 +244,284 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+  sonar:
+    name: SonarQube Cloud
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    needs:
+      - repository-configuration
+      - compatibility
+      - roslyn-components
+    if: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) || github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch' }}
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          show-progress: false
+
+      - name: Verify SONAR_TOKEN
+        shell: bash
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          if [ -z "${SONAR_TOKEN}" ]; then
+            echo "SONAR_TOKEN repository secret is required."
+            exit 1
+          fi
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          global-json-file: global.json
+
+      - name: Setup Java
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Restore tools
+        run: dotnet tool restore
+
+      - name: Restore
+        run: dotnet restore ./Dapper.FluentMap.slnx
+
+      - name: Begin Sonar analysis
+        shell: bash
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: >
+          dotnet sonarscanner begin
+          /k:"rodri-oliveira-dev_Dapper-FluentMap"
+          /o:"rodri-oliveira-dev"
+          /d:sonar.token="${SONAR_TOKEN}"
+          /d:sonar.host.url="https://sonarcloud.io"
+          /d:sonar.projectBaseDir="${GITHUB_WORKSPACE}"
+          /d:sonar.cs.vscoveragexml.reportsPaths="artifacts/coverage/sonar/coverage.xml"
+          /d:sonar.exclusions="benchmarks/**,test/Dapper.FluentMap.AotSmoke/**,eng/consumer-smoke/**,**/bin/**,**/obj/**,**/*.g.cs,**/*.generated.cs"
+          /d:sonar.coverage.exclusions="test/**,benchmarks/**,eng/consumer-smoke/**,**/*.g.cs,**/*.generated.cs"
+          /d:sonar.qualitygate.wait=true
+          /d:sonar.qualitygate.timeout=300
+
+      - name: Build Release
+        run: >
+          dotnet build ./Dapper.FluentMap.slnx
+          --configuration Release
+          --no-restore
+          --no-incremental
+          --disable-build-servers
+
+      - name: Test with coverage
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path './artifacts/coverage/sonar' | Out-Null
+          dotnet tool run dotnet-coverage -- collect `
+            --settings './eng/sonar-coverage.settings.xml' `
+            --output './artifacts/coverage/sonar/coverage.xml' `
+            --output-format xml `
+            pwsh -NoLogo -NoProfile -File './eng/run-sonar-tests.ps1'
+
+      - name: Verify coverage report
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $coveragePath = './artifacts/coverage/sonar/coverage.xml'
+          if (-not (Test-Path -LiteralPath $coveragePath)) {
+            throw "Coverage report was not created: $coveragePath"
+          }
+
+          [xml] $coverage = Get-Content -Raw -LiteralPath $coveragePath
+          $moduleNames = if ($coverage.results.modules.module) {
+            @($coverage.results.modules.module | ForEach-Object { $_.name })
+          } else {
+            @($coverage.CoverageSession.Modules.Module | ForEach-Object { $_.ModuleName })
+          }
+
+          if ($moduleNames -notcontains 'Dapper.FluentMap.dll') {
+            throw 'Coverage report does not contain production assembly Dapper.FluentMap.'
+          }
+
+          $unexpectedModules = @($moduleNames | Where-Object { $_ -match '(Tests|Benchmarks|AotSmoke)(\.dll)?$' })
+          if ($unexpectedModules.Count -gt 0) {
+            throw "Coverage report contains non-production modules: $($unexpectedModules -join ', ')"
+          }
+
+      - name: End Sonar analysis
+        id: sonar_end
+        shell: bash
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: dotnet sonarscanner end /d:sonar.token="${SONAR_TOKEN}"
+
+      - name: Report Sonar quality gate conditions
+        id: sonar_quality_gate
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_PROJECT_KEY: rodri-oliveira-dev_Dapper-FluentMap
+          SONAR_PULL_REQUEST: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+          marker="<!-- Dapper-FluentMap:sonar-quality-gate -->"
+          dashboard_url="https://sonarcloud.io/dashboard?id=${SONAR_PROJECT_KEY}&pullRequest=${SONAR_PULL_REQUEST}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_file="sonar-quality-gate-comment.md"
+
+          if [ -z "${SONAR_TOKEN:-}" ]; then
+            echo "status=UNKNOWN" >> "${GITHUB_OUTPUT}"
+            echo "lookup_failed=true" >> "${GITHUB_OUTPUT}"
+            {
+              echo "${marker}"
+              echo "### SonarQube Cloud failure"
+              echo
+              echo "The SonarQube Cloud job failed before Quality Gate conditions could be fetched."
+              echo
+              echo "Cause: \`SONAR_TOKEN\` was not available to the workflow."
+              echo
+              echo "- [Open workflow run](${run_url})"
+              echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"
+            } > "${comment_file}"
+            exit 0
+          fi
+
+          if ! response=$(curl --fail-with-body --silent --show-error \
+            -u "${SONAR_TOKEN}:" \
+            --get "https://sonarcloud.io/api/qualitygates/project_status" \
+            --data-urlencode "projectKey=${SONAR_PROJECT_KEY}" \
+            --data-urlencode "pullRequest=${SONAR_PULL_REQUEST}"); then
+            echo "status=UNKNOWN" >> "${GITHUB_OUTPUT}"
+            echo "lookup_failed=true" >> "${GITHUB_OUTPUT}"
+            {
+              echo "${marker}"
+              echo "### SonarQube Cloud failure"
+              echo
+              echo "The SonarQube Cloud job failed, and the workflow could not fetch Quality Gate conditions from SonarCloud."
+              echo
+              echo "Cause: SonarCloud Quality Gate API lookup failed."
+              echo
+              echo "- [Open workflow run](${run_url})"
+              echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"
+            } > "${comment_file}"
+            exit 0
+          fi
+
+          status=$(echo "${response}" | jq -r '.projectStatus.status // "UNKNOWN"')
+          echo "status=${status}" >> "${GITHUB_OUTPUT}"
+          echo "lookup_failed=false" >> "${GITHUB_OUTPUT}"
+          echo "SonarQube Cloud quality gate conditions:"
+          echo "${response}" | jq '{
+            status: .projectStatus.status,
+            conditions: [.projectStatus.conditions[]? | {
+              metricKey,
+              status,
+              errorThreshold,
+              actualValue
+            }]
+          }'
+
+          failed_conditions=$(echo "${response}" | jq -r '
+            [.projectStatus.conditions[]? | select(.status != "OK") |
+              "- `" + .metricKey + "`: status `" + .status + "`, actual `" + (.actualValue // "n/a") + "`, threshold `" + (.errorThreshold // "n/a") + "`"
+            ] | join("\n")
+          ')
+          condition_rows=$(echo "${response}" | jq -r '
+            [.projectStatus.conditions[]? |
+              "| `" + (.metricKey // "unknown") + "` | **" + (.status // "UNKNOWN") + "** | `" + (.actualValue // "n/a") + "` | `" + (.errorThreshold // "n/a") + "` |"
+            ] | join("\n")
+          ')
+
+          if [ "${status}" = "OK" ]; then
+            {
+              echo "${marker}"
+              echo "### SonarQube Cloud success"
+              echo
+              echo "The SonarQube Cloud Quality Gate passed for this PR."
+              echo
+              echo "Quality Gate status: **${status}**"
+              echo
+              if [ -n "${condition_rows}" ]; then
+                echo "| Metric | Status | Actual | Threshold |"
+                echo "| --- | --- | --- | --- |"
+                echo "${condition_rows}"
+                echo
+              fi
+              echo "- [Open workflow run](${run_url})"
+              echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"
+            } > "${comment_file}"
+          else
+            {
+              echo "${marker}"
+              echo "### SonarQube Cloud failure"
+              echo
+              echo "The SonarQube Cloud Quality Gate failed for this PR."
+              echo
+              echo "Quality Gate status: **${status}**"
+              echo
+              if [ -n "${failed_conditions}" ]; then
+                echo "Failed conditions:"
+                echo "${failed_conditions}"
+              else
+                echo "No failing Quality Gate condition was returned by SonarCloud."
+              fi
+              echo
+              echo "- [Open workflow run](${run_url})"
+              echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"
+            } > "${comment_file}"
+          fi
+
+      - name: Comment Sonar quality gate on PR
+        if: ${{ always() && github.event_name == 'pull_request' && (steps.sonar_quality_gate.outcome == 'success' || failure()) }}
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- Dapper-FluentMap:sonar-quality-gate -->";
+            const fallbackBody = [
+              marker,
+              "### SonarQube Cloud failure",
+              "",
+              "The SonarQube Cloud job failed before the workflow could prepare Quality Gate details.",
+              "",
+              `- [Open workflow run](${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID})`
+            ].join("\n");
+            const body = fs.existsSync("sonar-quality-gate-comment.md")
+              ? fs.readFileSync("sonar-quality-gate-comment.md", "utf8")
+              : fallbackBody;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100
+            });
+            const existing = comments.find(comment =>
+              comment.user?.type === "Bot" && comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body
+              });
+            }
+
   ci-gate:
     name: CI Gate
     runs-on: ubuntu-latest
@@ -251,6 +532,7 @@ jobs:
       - compatibility
       - roslyn-components
       - pack
+      - sonar
 
     steps:
       - name: Verify required jobs
@@ -260,11 +542,18 @@ jobs:
           echo "compatibility=${{ needs.compatibility.result }}"
           echo "roslyn-components=${{ needs.roslyn-components.result }}"
           echo "pack=${{ needs.pack.result }}"
+          echo "sonar=${{ needs.sonar.result }}"
 
           if [[ "${{ needs.repository-configuration.result }}" != "success" || \
                 "${{ needs.compatibility.result }}" != "success" || \
                 "${{ needs.roslyn-components.result }}" != "success" || \
                 "${{ needs.pack.result }}" != "success" ]]; then
             echo "One or more required CI jobs did not complete successfully."
+            exit 1
+          fi
+
+          if [[ "${{ needs.sonar.result }}" != "success" && \
+                "${{ needs.sonar.result }}" != "skipped" ]]; then
+            echo "SonarQube Cloud did not complete successfully."
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -369,6 +369,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_PROJECT_KEY: rodri-oliveira-dev_Dapper-FluentMap
           SONAR_PULL_REQUEST: ${{ github.event.pull_request.number }}
+          SONAR_END_OUTCOME: ${{ steps.sonar_end.outcome }}
         run: |
           set -uo pipefail
           marker="<!-- Dapper-FluentMap:sonar-quality-gate -->"
@@ -457,7 +458,7 @@ jobs:
               echo "- [Open workflow run](${run_url})"
               echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"
             } > "${comment_file}"
-          else
+          elif [ "${status}" = "ERROR" ]; then
             {
               echo "${marker}"
               echo "### SonarQube Cloud failure"
@@ -472,6 +473,19 @@ jobs:
               else
                 echo "No failing Quality Gate condition was returned by SonarCloud."
               fi
+              echo
+              echo "- [Open workflow run](${run_url})"
+              echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"
+            } > "${comment_file}"
+          else
+            {
+              echo "${marker}"
+              echo "### SonarQube Cloud not computed"
+              echo
+              echo "The SonarQube Cloud job did not produce computed Quality Gate conditions for this PR."
+              echo
+              echo "Quality Gate status: **${status}**"
+              echo "Scanner end outcome: **${SONAR_END_OUTCOME:-unknown}**"
               echo
               echo "- [Open workflow run](${run_url})"
               echo "- [Open SonarQube Cloud dashboard](${dashboard_url})"

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ For users moving from FluentMap 2.x, see [MIGRATION.md](MIGRATION.md).
 
 Keep changes small, compatible with the public API and covered by focused tests. `Dapper.FluentMap.slnx` is the preferred solution for current .NET SDKs; `Dapper.FluentMap.sln` remains available as a compatibility fallback. Typical local validation:
 
-SonarQube Cloud is part of the CI quality gate, with results published at the [project dashboard](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). Authorized SonarQube analysis requires the `SONAR_TOKEN` repository secret.
+SonarQube Cloud is part of the CI quality gate, with results published at the [project dashboard](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). Authorized SonarQube analysis requires the `SONAR_TOKEN` repository secret and the project configured for CI-based analysis.
 
 ```bash
 dotnet restore ./Dapper.FluentMap.slnx

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ For users moving from FluentMap 2.x, see [MIGRATION.md](MIGRATION.md).
 
 Keep changes small, compatible with the public API and covered by focused tests. `Dapper.FluentMap.slnx` is the preferred solution for current .NET SDKs; `Dapper.FluentMap.sln` remains available as a compatibility fallback. Typical local validation:
 
-SonarQube Cloud is part of the CI quality gate, with results published at the [project dashboard](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). Authorized SonarQube analysis requires the `SONAR_TOKEN` repository secret and the project configured for CI-based analysis.
+When enabled, SonarQube Cloud is part of the CI quality gate, with results published at the [project dashboard](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). Authorized SonarQube analysis requires the `SONAR_CI_ENABLED=true` repository variable, the `SONAR_TOKEN` repository secret and the project configured for CI-based analysis.
 
 ```bash
 dotnet restore ./Dapper.FluentMap.slnx

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # FluentMap
 
 [![CI](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rodri-oliveira-dev_Dapper-FluentMap&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap)
 [![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-512BD4?logo=dotnet&logoColor=white)](https://learn.microsoft.com/dotnet/standard/net-standard)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rodri-oliveira-dev_Dapper-FluentMap&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap)
 [![License: MIT](https://img.shields.io/github/license/rodri-oliveira-dev/Dapper-FluentMap)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/rodri-oliveira-dev/Dapper-FluentMap?style=flat&logo=github)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/stargazers)
 
@@ -480,6 +482,8 @@ For users moving from FluentMap 2.x, see [MIGRATION.md](MIGRATION.md).
 ## Contributing
 
 Keep changes small, compatible with the public API and covered by focused tests. `Dapper.FluentMap.slnx` is the preferred solution for current .NET SDKs; `Dapper.FluentMap.sln` remains available as a compatibility fallback. Typical local validation:
+
+SonarQube Cloud is part of the CI quality gate, with results published at the [project dashboard](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). Authorized SonarQube analysis requires the `SONAR_TOKEN` repository secret.
 
 ```bash
 dotnet restore ./Dapper.FluentMap.slnx

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # FluentMap
 
+[![CI](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml)
+[![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-512BD4?logo=dotnet&logoColor=white)](https://learn.microsoft.com/dotnet/standard/net-standard)
+[![License: MIT](https://img.shields.io/github/license/rodri-oliveira-dev/Dapper-FluentMap)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/rodri-oliveira-dev/Dapper-FluentMap?style=flat&logo=github)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/stargazers)
+
 English | [Português (Brasil)](README.pt-BR.md)
 
 FluentMap is an advanced mapping layer for Dapper. It lets you describe how .NET object properties map to database columns with fluent, strongly typed code, while keeping persistence attributes out of your POCOs.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,5 +1,10 @@
 # FluentMap
 
+[![CI](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml)
+[![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-512BD4?logo=dotnet&logoColor=white)](https://learn.microsoft.com/dotnet/standard/net-standard)
+[![License: MIT](https://img.shields.io/github/license/rodri-oliveira-dev/Dapper-FluentMap)](LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/rodri-oliveira-dev/Dapper-FluentMap?style=flat&logo=github)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/stargazers)
+
 [English](README.md) | Português (Brasil)
 
 FluentMap é uma camada avançada de mapeamento para Dapper. Ela permite descrever, com uma API fluente e fortemente tipada, como propriedades .NET se conectam a colunas de banco de dados, mantendo atributos de persistência fora dos POCOs.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -483,7 +483,7 @@ Para migrar do FluentMap 2.x, consulte [MIGRATION.md](MIGRATION.md).
 
 Mantenha mudanças pequenas, compatíveis com a API pública e cobertas por testes focados. `Dapper.FluentMap.slnx` é a solução preferencial para SDKs .NET atuais; `Dapper.FluentMap.sln` permanece disponível como fallback de compatibilidade. Validação local típica:
 
-SonarQube Cloud faz parte do quality gate da CI, com resultados publicados no [dashboard do projeto](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). A análise autorizada do SonarQube exige o secret de repositório `SONAR_TOKEN` e o projeto configurado para análise via CI.
+Quando habilitado, SonarQube Cloud faz parte do quality gate da CI, com resultados publicados no [dashboard do projeto](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). A análise autorizada do SonarQube exige a variável de repositório `SONAR_CI_ENABLED=true`, o secret de repositório `SONAR_TOKEN` e o projeto configurado para análise via CI.
 
 ```bash
 dotnet restore ./Dapper.FluentMap.slnx

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,7 +1,9 @@
 # FluentMap
 
 [![CI](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/actions/workflows/ci.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=rodri-oliveira-dev_Dapper-FluentMap&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap)
 [![.NET Standard 2.0](https://img.shields.io/badge/.NET%20Standard-2.0-512BD4?logo=dotnet&logoColor=white)](https://learn.microsoft.com/dotnet/standard/net-standard)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=rodri-oliveira-dev_Dapper-FluentMap&metric=coverage)](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap)
 [![License: MIT](https://img.shields.io/github/license/rodri-oliveira-dev/Dapper-FluentMap)](LICENSE)
 [![GitHub stars](https://img.shields.io/github/stars/rodri-oliveira-dev/Dapper-FluentMap?style=flat&logo=github)](https://github.com/rodri-oliveira-dev/Dapper-FluentMap/stargazers)
 
@@ -480,6 +482,8 @@ Para migrar do FluentMap 2.x, consulte [MIGRATION.md](MIGRATION.md).
 ## Contribuição
 
 Mantenha mudanças pequenas, compatíveis com a API pública e cobertas por testes focados. `Dapper.FluentMap.slnx` é a solução preferencial para SDKs .NET atuais; `Dapper.FluentMap.sln` permanece disponível como fallback de compatibilidade. Validação local típica:
+
+SonarQube Cloud faz parte do quality gate da CI, com resultados publicados no [dashboard do projeto](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). A análise autorizada do SonarQube exige o secret de repositório `SONAR_TOKEN`.
 
 ```bash
 dotnet restore ./Dapper.FluentMap.slnx

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -483,7 +483,7 @@ Para migrar do FluentMap 2.x, consulte [MIGRATION.md](MIGRATION.md).
 
 Mantenha mudanças pequenas, compatíveis com a API pública e cobertas por testes focados. `Dapper.FluentMap.slnx` é a solução preferencial para SDKs .NET atuais; `Dapper.FluentMap.sln` permanece disponível como fallback de compatibilidade. Validação local típica:
 
-SonarQube Cloud faz parte do quality gate da CI, com resultados publicados no [dashboard do projeto](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). A análise autorizada do SonarQube exige o secret de repositório `SONAR_TOKEN`.
+SonarQube Cloud faz parte do quality gate da CI, com resultados publicados no [dashboard do projeto](https://sonarcloud.io/summary/new_code?id=rodri-oliveira-dev_Dapper-FluentMap). A análise autorizada do SonarQube exige o secret de repositório `SONAR_TOKEN` e o projeto configurado para análise via CI.
 
 ```bash
 dotnet restore ./Dapper.FluentMap.slnx

--- a/eng/run-sonar-tests.ps1
+++ b/eng/run-sonar-tests.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+
+$testProjects = @(
+  './test/Dapper.FluentMap.Tests/Dapper.FluentMap.Tests.csproj',
+  './test/Dapper.FluentMap.GeneratedRegistration.Tests/Dapper.FluentMap.GeneratedRegistration.Tests.csproj',
+  './test/Dapper.FluentMap.DependencyInjection.Tests/Dapper.FluentMap.DependencyInjection.Tests.csproj',
+  './test/Dapper.FluentMap.Dommel.Tests/Dapper.FluentMap.Dommel.Tests.csproj',
+  './test/Dapper.FluentMap.ProviderCompatibility.Tests/Dapper.FluentMap.ProviderCompatibility.Tests.csproj',
+  './test/Dapper.FluentMap.Analyzers.Tests/Dapper.FluentMap.Analyzers.Tests.csproj',
+  './test/Dapper.FluentMap.Generators.Tests/Dapper.FluentMap.Generators.Tests.csproj'
+)
+
+foreach ($testProject in $testProjects) {
+  dotnet test $testProject --configuration Release --no-build --verbosity normal
+}

--- a/eng/sonar-coverage.settings.xml
+++ b/eng/sonar-coverage.settings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>(^|.*[\\/])Dapper\.FluentMap(\.(Analyzers|DependencyInjection|Dommel|Generators))?\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <ModulePath>(^|.*[\\/])Dapper\.FluentMap\..*Tests\.dll$</ModulePath>
+        <ModulePath>(^|.*[\\/])Dapper\.FluentMap\.AotSmoke\.dll$</ModulePath>
+        <ModulePath>(^|.*[\\/])Dapper\.FluentMap\.Benchmarks\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+        <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+    <Sources>
+      <Exclude>
+        <Source>.*[\\/]test[\\/].*</Source>
+        <Source>.*[\\/]benchmarks[\\/].*</Source>
+        <Source>.*[\\/]obj[\\/].*</Source>
+        <Source>.*\.g\.cs$</Source>
+        <Source>.*\.generated\.cs$</Source>
+      </Exclude>
+    </Sources>
+    <EnableStaticManagedInstrumentation>True</EnableStaticManagedInstrumentation>
+    <EnableDynamicManagedInstrumentation>True</EnableDynamicManagedInstrumentation>
+  </CodeCoverage>
+</Configuration>


### PR DESCRIPTION
## Summary

Adds a concise set of project badges to both the English and Brazilian Portuguese READMEs:

- CI status
- .NET Standard 2.0 target
- MIT license
- GitHub stars

NuGet/release badges are intentionally omitted for now because the currently published/latest release still points to the legacy 2.0.0 line while 3.0 is being modernized.

## Scope

- `README.md`
- `README.pt-BR.md`

No application or build behavior is changed.