### PR TITLE
Modernize agent guidance and decouple NuGet package identities

### DIFF
--- a/.agents/THIRD-PARTY-NOTICES.md
+++ b/.agents/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,39 @@
+# Third-Party Notices for Agent Skills
+
+Portions of the agent skills under `.agents/skills/` are adapted from the .NET team's `dotnet/skills` repository:
+
+- Source: https://github.com/dotnet/skills
+- Source revision used for this import: `c4a3f7ad4fd8fb50c02a42a6375c0aba4f92e9f7`
+- Imported/adapted skills in this change:
+  - `authoring-github-workflows`
+  - `nuget-trusted-publishing`
+  - `test-gap-analysis`
+  - `microbenchmarking`
+  - `directory-build-organization`
+  - `binlog-failure-analysis`
+
+The imported material is licensed under the MIT License:
+
+> The MIT License (MIT)
+>
+> Copyright (c) .NET Foundation and Contributors
+>
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+>
+> The above copyright notice and this permission notice shall be included in all
+> copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+> SOFTWARE.
+
+The local copies are adapted to Dapper-FluentMap's `AGENTS.md`, public-library compatibility rules, existing explicit dependency-versioning model, multi-package release/recovery flow, SHA-pinned GitHub Actions, and deterministic validation policies.

--- a/.agents/skills/authoring-github-workflows/SKILL.md
+++ b/.agents/skills/authoring-github-workflows/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: authoring-github-workflows
+description: "Author and review GitHub Actions workflow YAML safely so syntactically-valid YAML can't ship a workflow that GitHub Actions refuses to run. USE FOR: editing, adding, or reviewing any file under .github/workflows/, writing run-name/name/if/env/run values that contain ${{ }} expressions, diagnosing workflow-load failures, deciding when a workflow scalar must be quoted, and validating workflows with actionlint. DO NOT USE FOR: non-GitHub-Actions YAML. SCOPE: syntactic/structural workflow correctness; pair with ci-release-governance for semantic CI/release design."
+license: MIT
+---
+
+# Authoring GitHub Actions Workflows Safely
+
+GitHub Actions workflow files are YAML, but valid YAML is not the same as a valid workflow. A file can parse as YAML yet still be rejected by GitHub Actions before any job starts.
+
+> **Repository integration:** `AGENTS.md` and the existing Dapper-FluentMap workflows are authoritative. Preserve the repository's SHA-pinned actions, least-privilege permissions, release/recovery semantics, `master` default branch, Sonar Quality Gate, and multi-package publishing rules. Use `ci-release-governance` for what a workflow should do; use this skill for whether the workflow is structurally valid and safely authored.
+
+## When to Use
+
+- Editing, adding, or reviewing `.github/workflows/*.yml`.
+- Writing `run-name`, `name`, `if`, `env`, `with`, or `run` values containing `${{ }}` expressions.
+- Diagnosing a workflow rejected before jobs start.
+- Reviewing download steps, permissions, expressions, quoting, or reusable workflow syntax.
+
+## The `#` trap
+
+In an unquoted YAML scalar, a space followed by `#` begins a comment and can truncate a GitHub expression.
+
+```yaml
+# BAD
+run-name: ${{ inputs.pr_number != '' && format('Evaluate PR #{0}', inputs.pr_number) || '' }}
+
+# GOOD
+run-name: "${{ inputs.pr_number != '' && format('Evaluate PR #{0}', inputs.pr_number) || '' }}"
+```
+
+Quote expression-bearing scalars whenever literal `#`, colon-space, leading special characters, or significant whitespace make YAML interpretation ambiguous.
+
+## Workflow
+
+### 1. Identify changed workflows
+
+```bash
+git diff --name-only origin/master... -- .github/workflows/
+```
+
+### 2. Inspect repository semantics before editing
+
+For release-related changes, read the existing `release.yml`, recovery workflow, `eng/package-catalog.json`, and relevant publishing scripts. Do not replace established behavior with a generic workflow pattern.
+
+### 3. Validate with actionlint
+
+Prefer a repository-owned pinned validation command when available. For manual validation:
+
+```bash
+ACTIONLINT_VERSION=1.7.12
+ACTIONLINT_SHA256=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+curl \
+  --fail \
+  --silent \
+  --show-error \
+  --location \
+  --proto '=https' \
+  --proto-redir '=https' \
+  --output actionlint.tar.gz \
+  "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum -c -
+tar -xzf actionlint.tar.gz actionlint
+./actionlint -shellcheck= -pyflakes= -color .github/workflows/*.yml
+```
+
+Pin both version and checksum. Restrict both initial and redirected downloads to HTTPS.
+
+The repository also uses GitHub-workflow JSON schema validation; preserve that existing gate rather than substituting actionlint for it.
+
+### 4. Review security-sensitive workflow behavior
+
+- keep actions SHA-pinned;
+- keep permissions minimal and job-scoped when practical;
+- do not expose secrets to fork PRs;
+- do not add `continue-on-error` to bypass required quality/release checks;
+- do not weaken NuGet OIDC, artifact validation, release recovery, or Sonar Quality Gate behavior;
+- for network downloads that follow redirects, enforce HTTPS redirects and validate checksums where feasible.
+
+## Validation
+
+- [ ] Changed workflow files pass repository schema validation
+- [ ] `actionlint` exits 0 when used
+- [ ] Risky `${{ }}` scalars are quoted
+- [ ] Actions remain SHA-pinned
+- [ ] Permissions remain least privilege
+- [ ] Redirect-following downloads enforce HTTPS
+- [ ] Existing release, recovery, CI Gate, and Sonar semantics remain intact unless intentionally changed
+
+## References
+
+- [actionlint](https://github.com/rhysd/actionlint)
+- [GitHub Actions workflow syntax](https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions)
+- [`ci-release-governance`](../ci-release-governance/SKILL.md)

--- a/.agents/skills/binlog-failure-analysis/SKILL.md
+++ b/.agents/skills/binlog-failure-analysis/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: binlog-failure-analysis
+description: "Analyze MSBuild binary logs to diagnose build failures. USE FOR: unclear MSBuild errors, cascading failures across the multi-project solution, tracing target execution/order, and inspecting evaluated properties/items. Requires an existing .binlog or explicit permission to generate one. DO NOT USE FOR: non-MSBuild build systems."
+license: MIT
+---
+
+# Analyzing MSBuild Failures with Binary Logs
+
+This skill diagnoses MSBuild failures from `.binlog` evidence.
+
+> **Dapper-FluentMap integration:** prefer the narrowest failing project or `Dapper.FluentMap.slnx` command. Consider root `Directory.Build.props`, `Directory.Build.targets`, project-specific package versions, analyzer/generator projects, pack targets, and compatibility validation when tracing failures. A binlog-aware MCP/tool is optional, not assumed. Do not attempt to read `.binlog` as plain text.
+
+## Preferred path — structured binlog tooling when available
+
+If a binlog-aware tool is available, inspect:
+
+- errors and warnings;
+- evaluated MSBuild properties;
+- `PackageReference` and `ProjectReference` items;
+- project evaluation data;
+- target execution/order;
+- the first causal failure before cascaded project failures.
+
+Stop once the cause and affected target/property chain are sufficiently established.
+
+## Fallback — replay binary log to focused text logs
+
+```bash
+dotnet msbuild build.binlog -noconlog \
+  -fl  -flp:v=diag\;logfile=full.log\;performancesummary \
+  -fl1 -flp1:errorsonly\;logfile=errors.log \
+  -fl2 -flp2:warningsonly\;logfile=warnings.log
+```
+
+PowerShell requires appropriate quoting around semicolon-delimited logger parameters.
+
+Then search generated text logs, not the binary file:
+
+```bash
+cat errors.log
+grep -n -B2 -A2 "CS0246" full.log
+grep -i "CoreCompile.*FAILED\|Build FAILED\|error MSB" full.log
+```
+
+## Generating a binlog when needed
+
+If no binlog exists and the task requires one:
+
+```bash
+dotnet build ./Dapper.FluentMap.slnx --configuration Release /bl:build.binlog
+```
+
+Prefer a narrower failing `.csproj` command when it reproduces the issue. Treat `.binlog` and replay logs as temporary diagnostic artifacts unless explicitly requested otherwise.
+
+## Repository-specific checks
+
+When the failure involves packaging/release, correlate the binlog with:
+
+- `Directory.Build.props` / `Directory.Build.targets`;
+- `eng/package-catalog.json`;
+- package validation targets/scripts;
+- analyzer/generator project settings;
+- `netstandard2.0` compatibility constraints;
+- explicit package-version properties/`PackageReference` values.
+
+## Validation
+
+- [ ] Cause is supported by properties/items/targets from the log rather than guessed from the final console error
+- [ ] Cascading errors are distinguished from the first causal failure
+- [ ] No binary log was parsed with plain-text tools
+- [ ] Temporary diagnostic artifacts are not committed
+- [ ] Fix is validated with the repository's deterministic build/test and pack checks when relevant

--- a/.agents/skills/ci-release-governance/SKILL.md
+++ b/.agents/skills/ci-release-governance/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: ci-release-governance
+description: Use this skill to review or adjust Dapper-FluentMap GitHub Actions, packaging, NuGet publishing, versioning, release, rollback, recovery, provenance, and automation security. Do not use for production code changes without pipeline impact.
+license: MIT
+---
+
+# Purpose
+
+Guide CI/CD, packaging, versioning, release, and recovery changes according to the automation that actually exists in Dapper-FluentMap.
+
+# Primary Rule
+
+Inspect `.github/workflows/` and relevant `eng/**` scripts before assuming any automation. Do not document or depend on workflows, scripts, package sets, branches, or publishing behavior that are not present in the current tree.
+
+# Current Automation Facts
+
+- The development and release branch is `master`.
+- `ci.yml` runs on pushes to `master`, pull requests, and manual dispatch.
+- `release.yml` is manual (`workflow_dispatch`) and rejects releases not started from `master`.
+- `release.yml` validates a SemVer input without `v`, rejects versions below major `3`, checks existing tags, checks NuGet availability for all published package IDs, builds/tests/packs, validates artifacts, runs consumer smoke tests, creates a tag, publishes to NuGet.org and GitHub Packages, creates/updates a GitHub Release, and runs rollback on partial failure.
+- `release-recovery-missing-nuget.yml` is a one-off recovery workflow for missing NuGet.org `3.0.0` packages from a fixed commit. Do not generalize it without explicit release-recovery scope.
+- `sonar-quality-issues.yml` syncs high-impact Sonar findings to GitHub issues when `SONAR_CI_ENABLED` and `SONAR_TOKEN` are configured.
+- Package validation scripts live under `eng/`: `validate-slnx-equivalence.ps1`, `validate-package-metadata.ps1`, `validate-release-artifacts.ps1`, `run-sonar-tests.ps1`, `rollback-release.ps1`, and consumer smoke scripts.
+
+# When To Use
+
+- Changes to `.github/workflows/**` or `eng/**` automation.
+- Restore/build/test/coverage/pack/publish changes in CI.
+- Versioning, SemVer, tag, artifact, Source Link/provenance, package metadata, or package count changes.
+- NuGet.org, GitHub Packages, OIDC, `NuGet/login`, permissions, environments, concurrency, credentials, rollback, or recovery work.
+- Documentation changes that describe CI, packaging, release, or recovery behavior.
+
+# When Not To Use
+
+- Functional source changes with no pipeline impact: use `dotnet-library-change`.
+- Pure behavior-preserving code refactoring: use `dotnet-refactoring-engineer`.
+- Ordinary tests with no CI or package behavior change.
+- Running a publication/release operation without explicit user request.
+
+# Process
+
+1. Read root `AGENTS.md`, existing workflows, and relevant `eng` scripts.
+2. Identify triggers, branch guards, permissions, credentials, version sources, artifacts, commands, package IDs, and rollback/recovery paths.
+3. Preserve the real package set unless the task explicitly changes it:
+   - `Dapper.FluentMap`
+   - `Dapper.FluentMap.Dommel`
+   - `Dapper.FluentMap.DependencyInjection`
+   - `Dapper.FluentMap.Analyzers`
+   - `Dapper.FluentMap.Generators`
+4. Preserve one effective release version source per flow. `Directory.Build.props` defines `FluentMapPackageVersionPrefix`; release passes the requested version through MSBuild `Version`.
+5. Preserve validation order: restore, audit when applicable, build, test, pack, validate artifacts, smoke test when relevant, then tag/publish/release.
+6. Preserve minimum required permissions; avoid broad write permissions.
+7. Keep secrets out of files and logs. Prefer the existing OIDC/Trusted Publishing pattern for NuGet.org unless explicit requirements justify a different approach.
+8. Ensure failure before package publication prevents later release announcement. Ensure partial release failure has an explicit rollback or recovery story.
+9. Update documentation only for behavior that really exists after the change.
+10. Review the diff for import-source assumptions, wrong branch names, incorrect package identities, fixed old versions, nonexistent scripts, or one-package assumptions.
+
+# Validation
+
+For workflow-only changes, use the cheapest reliable checks first:
+
+```bash
+rg --files .github/workflows eng
+```
+
+For package/release pipeline changes, validate with the actual repository commands:
+
+```bash
+dotnet restore ./Dapper.FluentMap.slnx
+dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
+dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build
+dotnet pack ./Dapper.FluentMap.slnx --configuration Release --no-build --output ./artifacts/packages
+./eng/validate-package-metadata.ps1 -PackageDirectory './artifacts/packages'
+```
+
+Use `./eng/validate-release-artifacts.ps1` and `./eng/consumer-smoke/run-consumer-smoke.ps1` when release artifacts or consumer package behavior are in scope.
+
+# Restrictions
+
+- Do not run `dotnet nuget push`, create tags, create GitHub Releases, trigger release workflows, or publish external artifacts unless explicitly requested.
+- Do not replace temporary OIDC-based publishing with persistent API keys without explicit scope and security review.
+- Do not remove restore/build/test/pack/package validation to reduce CI time without a documented replacement.
+- Do not change package IDs, package count checks, version guards, artifact manifests, checksums, provenance, or rollback behavior incidentally.
+- Do not assume administrative settings such as environments, repository variables, rulesets, trusted publishing policies, or secrets exist beyond what workflows reference.
+
+# Quality Bar
+
+A good automation change matches the current repository, uses minimum permissions, keeps versioning and package identity explicit, validates before publication, preserves provenance and recovery paths, fails diagnostically, and documents only real capabilities.

--- a/.agents/skills/ci-release-governance/SKILL.md
+++ b/.agents/skills/ci-release-governance/SKILL.md
@@ -18,7 +18,7 @@ Inspect `.github/workflows/` and relevant `eng/**` scripts before assuming any a
 - `ci.yml` runs on pushes to `master`, pull requests, and manual dispatch.
 - `release.yml` is manual (`workflow_dispatch`) and rejects releases not started from `master`.
 - `release.yml` validates a SemVer input without `v`, rejects versions below major `3`, checks existing tags, checks NuGet availability for all published package IDs, builds/tests/packs, validates artifacts, runs consumer smoke tests, creates a tag, publishes to NuGet.org and GitHub Packages, creates/updates a GitHub Release, and runs rollback on partial failure.
-- `release-recovery-missing-nuget.yml` is a one-off recovery workflow for missing NuGet.org `3.0.0` packages from a fixed commit. Do not generalize it without explicit release-recovery scope.
+- `release-recovery-missing-nuget.yml` recovers future partial NuGet.org publication by rebuilding the validated commit, validating artifacts, accepting only an existing tag that points to that commit, and publishing only package versions that are genuinely missing.
 - `sonar-quality-issues.yml` syncs high-impact Sonar findings to GitHub issues when `SONAR_CI_ENABLED` and `SONAR_TOKEN` are configured.
 - Package validation scripts live under `eng/`: `validate-slnx-equivalence.ps1`, `validate-package-metadata.ps1`, `validate-release-artifacts.ps1`, `run-sonar-tests.ps1`, `rollback-release.ps1`, and consumer smoke scripts.
 
@@ -44,9 +44,9 @@ Inspect `.github/workflows/` and relevant `eng/**` scripts before assuming any a
 3. Preserve the real package set unless the task explicitly changes it:
    - `Dapper.FluentMap`
    - `Dapper.FluentMap.Dommel`
-   - `Dapper.FluentMap.DependencyInjection`
-   - `Dapper.FluentMap.Analyzers`
-   - `Dapper.FluentMap.Generators`
+   - `FluentMap.DependencyInjection`
+   - `FluentMap.Analyzers`
+   - `FluentMap.Generators`
 4. Preserve one effective release version source per flow. `Directory.Build.props` defines `FluentMapPackageVersionPrefix`; release passes the requested version through MSBuild `Version`.
 5. Preserve validation order: restore, audit when applicable, build, test, pack, validate artifacts, smoke test when relevant, then tag/publish/release.
 6. Preserve minimum required permissions; avoid broad write permissions.

--- a/.agents/skills/directory-build-organization/SKILL.md
+++ b/.agents/skills/directory-build-organization/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: directory-build-organization
+description: "Guide for organizing MSBuild infrastructure with Directory.Build.props, Directory.Build.targets, Directory.Packages.props when present, and related repository build files. USE FOR: structuring multi-project repos, consolidating duplicated properties, understanding MSBuild evaluation order, or evaluating whether Central Package Management would be appropriate. Critical pitfall: TargetFramework-dependent properties in .props may evaluate too early."
+license: MIT
+---
+
+# Organizing Build Infrastructure with Directory.Build Files
+
+> **Dapper-FluentMap integration:** this repository already uses root `Directory.Build.props` and `Directory.Build.targets`, plus a separate `eng/consumer-smoke/Directory.Build.props`. It does **not** currently use `Directory.Packages.props`/Central Package Management. Preserve that actual structure unless CPM migration is explicitly requested and justified. Package identity also lives in `eng/package-catalog.json`; do not move PackageIds casually into generic build defaults.
+
+## Evaluation order
+
+```text
+Directory.Build.props → SDK .props → .csproj → SDK .targets → Directory.Build.targets
+```
+
+| Use `.props` for | Use `.targets` for |
+|---|---|
+| property defaults | custom build targets |
+| common items | late-bound property overrides |
+| shared package/assembly metadata | logic depending on final SDK properties |
+| shared dependency-version properties | post-build/pack validation |
+
+### TargetFramework pitfall
+
+Property conditions on `$(TargetFramework)` in `.props` files can silently fail for single-target projects because the project may set the TFM after `.props` import. Move such property logic to `.targets` or the project file. See [references/targetframework-props-pitfall.md](references/targetframework-props-pitfall.md).
+
+## Dependency-version organization
+
+The repository currently uses a mixed explicit model:
+
+- shared ranges/properties such as Dapper/Dommel versions live in `Directory.Build.props`;
+- many package versions remain explicit in individual `.csproj` files;
+- consumer-smoke package versioning is isolated under `eng/consumer-smoke/Directory.Build.props`.
+
+Do not describe this repository as using CPM unless a `Directory.Packages.props` with `ManagePackageVersionsCentrally` actually exists. A future CPM migration is a dedicated dependency-governance change, not incidental cleanup.
+
+## Multi-level Directory.Build files
+
+MSBuild auto-imports the first `Directory.Build.props`/`.targets` it finds walking upward. If a subtree intentionally uses another file, verify whether it needs to import the parent or intentionally isolates itself. See [references/multi-level-examples.md](references/multi-level-examples.md).
+
+## Workflow
+
+1. Audit relevant `.csproj`, root `Directory.Build.props`, `Directory.Build.targets`, and any subtree build files.
+2. Identify duplicated vs project-specific settings.
+3. Preserve ownership of package identity, versioning, compatibility, analyzers, warnings, pack metadata and consumer-smoke behavior.
+4. Move only clearly shared defaults into `.props`.
+5. Keep custom targets/late SDK-dependent logic in `.targets`.
+6. Validate SLNX equivalence if project structure changes.
+7. Validate restore/build/test and pack/consumer-smoke when packaging semantics could be affected.
+
+Useful diagnosis:
+
+```bash
+dotnet msbuild -pp:output.xml path/to/Project.csproj
+```
+
+## Validation
+
+- [ ] No `TargetFramework`-dependent property was moved to an early `.props` evaluation point
+- [ ] Existing explicit dependency-version model remains consistent unless migration was in scope
+- [ ] Project-specific settings were not generalized without evidence
+- [ ] `eng/package-catalog.json` remains authoritative for package identities
+- [ ] Restore/build/test still pass
+- [ ] Packaging metadata/output remains unchanged unless intentionally modified
+
+See [references/common-patterns.md](references/common-patterns.md) for common layouts and validation examples.

--- a/.agents/skills/directory-build-organization/references/common-patterns.md
+++ b/.agents/skills/directory-build-organization/references/common-patterns.md
@@ -1,0 +1,31 @@
+# Common Directory.Build Patterns
+
+## Conditional Settings by Project Type
+
+Project naming can help with repo-owned conventions, but do not infer behavior solely from naming when explicit `IsTestProject`, `IsPackable`, or SDK metadata is available.
+
+Use `Directory.Build.targets` for conditions on late SDK-defined properties such as `OutputType`:
+
+```xml
+<PropertyGroup Condition="'$(OutputType)' == 'Exe'">
+  <SelfContained>false</SelfContained>
+</PropertyGroup>
+```
+
+## Post-Pack Validation
+
+Custom targets can validate expected package output after `Pack` when that belongs to repository policy:
+
+```xml
+<Target Name="ValidatePackageOutput" AfterTargets="Pack"
+        Condition="'$(IsPackable)' == 'true'">
+  <Error Text="Package was not created at the expected path"
+         Condition="!Exists('$(PackageOutputPath)$(PackageId).$(PackageVersion).nupkg')" />
+</Target>
+```
+
+In Dapper-FluentMap, prefer the existing `eng/validate-package-metadata.ps1`, `eng/validate-release-artifacts.ps1`, package catalog, and consumer-smoke validation over adding duplicate enforcement.
+
+## Artifact Output Layout
+
+`ArtifactsPath` can centralize `bin`, `obj`, and publish artifacts under a repository-level `artifacts/` directory. Adopt it only when compatible with existing scripts/workflows; changing artifact layout can break CI, release packaging, recovery, and consumer-smoke tooling.

--- a/.agents/skills/directory-build-organization/references/multi-level-examples.md
+++ b/.agents/skills/directory-build-organization/references/multi-level-examples.md
@@ -1,0 +1,54 @@
+# Multi-level Directory.Build Examples
+
+Use multi-level `Directory.Build.props` only when subtrees genuinely need distinct policy. MSBuild automatically stops at the first matching file it finds while walking upward, so an inner file can intentionally isolate a subtree or explicitly import the parent when inheritance is required.
+
+## Root
+
+```xml
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>
+```
+
+## Child props importing parent
+
+```xml
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))"
+          Condition="Exists('$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))')" />
+
+  <PropertyGroup>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+</Project>
+```
+
+## Dapper-FluentMap note
+
+The repository currently has a separate `eng/consumer-smoke/Directory.Build.props`. Before adding an import to the root file, determine whether that subtree is intentionally isolated. Do not change its package-version behavior incidentally.
+
+## Central Package Management example
+
+If CPM is intentionally adopted in a future dedicated change, package versions can move to `Directory.Packages.props`:
+
+```xml
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Example.Package" Version="1.2.3" />
+  </ItemGroup>
+</Project>
+```
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Example.Package" />
+</ItemGroup>
+```
+
+Do not treat this example as the repository's current state; Dapper-FluentMap currently uses explicit project package versions.

--- a/.agents/skills/directory-build-organization/references/targetframework-props-pitfall.md
+++ b/.agents/skills/directory-build-organization/references/targetframework-props-pitfall.md
@@ -1,0 +1,31 @@
+# TargetFramework conditions in .props files
+
+**Smell:** property conditions such as `<PropertyGroup Condition="'$(TargetFramework)' == '...'">` inside `Directory.Build.props` or another `.props` imported before the project body.
+
+## Why it matters
+
+`$(TargetFramework)` is not reliably available during early `.props` evaluation for single-target projects. A condition can silently evaluate against an empty value.
+
+```xml
+<!-- BAD in Directory.Build.props -->
+<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <DefineConstants>$(DefineConstants);MY_FEATURE</DefineConstants>
+</PropertyGroup>
+```
+
+Prefer late evaluation:
+
+```xml
+<!-- GOOD in Directory.Build.targets -->
+<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <DefineConstants>$(DefineConstants);MY_FEATURE</DefineConstants>
+</PropertyGroup>
+```
+
+or keep the condition in the project file when it is project-specific.
+
+## Important distinction
+
+The warning is about **property** conditions evaluated too early. Item and Target conditions are evaluated differently and can validly depend on `TargetFramework` in scenarios where an early property assignment cannot.
+
+Do not mechanically move safe item conditions merely because they mention `TargetFramework`. In Dapper-FluentMap, public packages preserve `netstandard2.0`, so any TFM-sensitive reorganization is compatibility-sensitive and must be validated deliberately.

--- a/.agents/skills/dotnet-issue-implementation/SKILL.md
+++ b/.agents/skills/dotnet-issue-implementation/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: dotnet-issue-implementation
+description: Use this skill to turn a well-defined issue into a small Dapper-FluentMap library change with requirements, implementation, tests, validation, and Definition of Done traceability. Do not use for open-ended bug investigation or PR review.
+license: MIT
+---
+
+# Purpose
+
+Implement a defined issue end to end without expanding scope, while preserving Dapper-FluentMap's public contracts, package boundaries, compatibility promises, and release safety.
+
+# Process
+
+1. Read root `AGENTS.md`, then the full issue or user-provided requirements.
+2. Extract the problem, expected behavior, constraints, Definition of Done, non-goals, and ambiguities.
+3. Search before opening large files. Locate only the relevant contracts, implementation, tests, package metadata, docs, and workflows.
+4. Identify the affected package(s): core, Dommel, DependencyInjection, Analyzers, Generators, tests, benchmarks, docs, or CI/release.
+5. Check whether the change affects public API, source/binary/behavior compatibility, Dapper integration, global state/cache behavior, dependencies, package output, or release flow.
+6. Choose the smallest implementation that satisfies the issue without opportunistic modernization.
+7. Add or update tests for behavior changes. For bugs, prefer a regression test that fails before the fix when practical.
+8. Update `README.md`, `COMPATIBILITY.md`, `MIGRATION.md`, XML docs, or `CHANGELOG.md` only when the consumer-facing contract changes.
+9. Run the nearest validation from `AGENTS.md`; broaden to solution or package validation only when the risk warrants it.
+10. Review the complete diff and mark each DoD item as satisfied, blocked, or not applicable.
+
+# Combine With
+
+- `dotnet-library-change` when production code, project files, dependencies, public contracts, or package metadata change.
+- `dotnet-refactoring-engineer` when the implementation includes behavior-preserving restructuring.
+- `ci-release-governance` when workflows, packaging, versioning, release, or recovery are involved.
+- `dotnet-pr-review` only when the task is to review an existing diff rather than implement it.
+
+# Dapper-FluentMap Constraints
+
+- The default branch is `master`; do not implement on `master`.
+- Treat this as a public multi-package .NET library, not an application.
+- Do not assume project name, assembly name, namespace, path, and NuGet `PackageId` are the same identity.
+- Preserve `netstandard2.0` for public packages unless the issue explicitly changes compatibility.
+- Keep core focused on mapping; do not add ORM, CRUD, SQL generation, migrations, or connection abstractions as incidental scope.
+- Do not publish, tag, release, or push unless explicitly requested by the user.
+
+# Expected Output
+
+Report what changed, main files, validation commands and results, DoD status, compatibility impact, and remaining risks or blockers.
+
+# Quality Bar
+
+A good issue implementation satisfies the stated DoD with the smallest coherent diff, tests the relevant observable behavior, preserves unrelated contracts, and leaves validation evidence proportional to the risk.

--- a/.agents/skills/dotnet-library-change/SKILL.md
+++ b/.agents/skills/dotnet-library-change/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: dotnet-library-change
+description: Use this skill when changing Dapper-FluentMap production code, public contracts, project files, PackageIds, package metadata, dependencies, or related tests. Do not use for pure CI/release work or behavior-preserving refactoring as the primary task.
+license: MIT
+---
+
+# Purpose
+
+Guide small, safe changes to this public multi-package .NET library while preserving build, tests, packaging, and public compatibility.
+
+# When To Use
+
+- Changes under `src/**`.
+- Behavior changes requiring tests under `test/**`.
+- Changes to `.csproj`, targets, dependencies, public types/members, XML docs, or package metadata.
+- Any task that may affect package identity, assembly identity, namespace, dependency ranges, trimming/AOT annotations, analyzers, generators, or consumer compatibility.
+
+# When Not To Use
+
+- Behavior-preserving refactoring is the main task: use `dotnet-refactoring-engineer`.
+- Workflows, release, NuGet publishing, or recovery are the main task: use `ci-release-governance`.
+- Reviewing an existing PR/diff is the task: use `dotnet-pr-review`.
+- The task changes only agent guidance or documentation with no library behavior impact.
+
+# Process
+
+1. Read root `AGENTS.md` and the files directly related to the requested change.
+2. Identify the affected package(s): `Dapper.FluentMap`, `Dapper.FluentMap.Dommel`, `Dapper.FluentMap.DependencyInjection`, `Dapper.FluentMap.Analyzers`, or `Dapper.FluentMap.Generators`.
+3. Determine whether the change affects public API, source/binary/behavior compatibility, target frameworks, dependency ranges, Dapper/Dommel integration, global state/cache, package output, or documentation.
+4. Preserve independent identities: project name, path, assembly name, namespace, and NuGet `PackageId` are not interchangeable.
+5. Implement the smallest coherent change using existing project patterns.
+6. Add or update tests for observable behavior changes; use regression tests for bug fixes.
+7. Update consumer documentation and changelog only when the public contract or documented behavior changes.
+8. For dependency, target, PackageId, metadata, or pack output changes, combine with `ci-release-governance`.
+9. Run targeted validation first, then broader solution or package validation when risk requires it.
+10. Review the full diff for unrelated modernization, formatting churn, project metadata drift, or weakened validation.
+
+# Repository Baseline
+
+- Public packages currently target `netstandard2.0`.
+- The shared package version base is `FluentMapPackageVersionPrefix` in `Directory.Build.props`, with an explicit `Version` override in release workflows.
+- Package IDs currently include:
+  - `Dapper.FluentMap`
+  - `Dapper.FluentMap.Dommel`
+  - `Dapper.FluentMap.DependencyInjection`
+  - `Dapper.FluentMap.Analyzers`
+  - `Dapper.FluentMap.Generators`
+- Dependency versions are declared where the current project files declare them; this repository does not currently use Central Package Management.
+- `Dapper.FluentMap.slnx` is preferred for current SDK validation; `Dapper.FluentMap.sln` remains a compatibility fallback.
+
+# Validation
+
+Use the commands from `AGENTS.md` that match the risk. As a starting point:
+
+```bash
+dotnet restore ./Dapper.FluentMap.slnx
+dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
+dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build
+```
+
+When package output, metadata, dependency ranges, targets, or release compatibility are affected, also run pack validation using the actual `eng` scripts documented in `AGENTS.md`.
+
+# Restrictions
+
+- Do not change `PackageId`, targets, dependency ranges, authors, license, URLs, Source Link/provenance, or package readme/icon behavior without explicit scope.
+- Do not add package-management systems, lock-file policy, source generators, analyzers, nullable, NativeAOT/trimming claims, or SDK upgrades as incidental work.
+- Do not make internals public just for tests.
+- Do not reduce warnings, tests, analyzers, audit, or package validation to get a green run.
+- Do not publish packages, create tags, or trigger releases unless explicitly requested.
+
+# Quality Bar
+
+A good library change resolves the requested behavior with a focused diff, preserves unrelated contracts, tests the relevant observable behavior, and keeps build/test/pack expectations consistent with the repository baseline.

--- a/.agents/skills/dotnet-library-change/SKILL.md
+++ b/.agents/skills/dotnet-library-change/SKILL.md
@@ -25,7 +25,7 @@ Guide small, safe changes to this public multi-package .NET library while preser
 # Process
 
 1. Read root `AGENTS.md` and the files directly related to the requested change.
-2. Identify the affected package(s): `Dapper.FluentMap`, `Dapper.FluentMap.Dommel`, `Dapper.FluentMap.DependencyInjection`, `Dapper.FluentMap.Analyzers`, or `Dapper.FluentMap.Generators`.
+2. Identify the affected package(s): `Dapper.FluentMap`, `Dapper.FluentMap.Dommel`, `FluentMap.DependencyInjection`, `FluentMap.Analyzers`, or `FluentMap.Generators`.
 3. Determine whether the change affects public API, source/binary/behavior compatibility, target frameworks, dependency ranges, Dapper/Dommel integration, global state/cache, package output, or documentation.
 4. Preserve independent identities: project name, path, assembly name, namespace, and NuGet `PackageId` are not interchangeable.
 5. Implement the smallest coherent change using existing project patterns.
@@ -42,9 +42,9 @@ Guide small, safe changes to this public multi-package .NET library while preser
 - Package IDs currently include:
   - `Dapper.FluentMap`
   - `Dapper.FluentMap.Dommel`
-  - `Dapper.FluentMap.DependencyInjection`
-  - `Dapper.FluentMap.Analyzers`
-  - `Dapper.FluentMap.Generators`
+  - `FluentMap.DependencyInjection`
+  - `FluentMap.Analyzers`
+  - `FluentMap.Generators`
 - Dependency versions are declared where the current project files declare them; this repository does not currently use Central Package Management.
 - `Dapper.FluentMap.slnx` is preferred for current SDK validation; `Dapper.FluentMap.sln` remains a compatibility fallback.
 

--- a/.agents/skills/dotnet-pr-review/SKILL.md
+++ b/.agents/skills/dotnet-pr-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: dotnet-pr-review
+description: Use this skill to review a Dapper-FluentMap pull request or diff for correctness, regressions, compatibility, tests, performance, security, packaging, release, and maintainability. Do not use to implement PR changes unless explicitly asked.
+license: MIT
+---
+
+# Purpose
+
+Review changes for real risk and observable behavior, producing actionable findings instead of cosmetic comments.
+
+# Review Process
+
+1. Read root `AGENTS.md`, the PR description, linked issue, and the diff.
+2. Understand the intended behavior before evaluating the implementation.
+3. Review the diff first. Open full files only when the surrounding contract or call path is unclear.
+4. Check correctness, public API/source/binary/behavior compatibility, SemVer impact, Dapper behavior, global state/cache, concurrency, dependencies, performance, security, tests, docs, CI, package output, and release safety.
+5. Confirm every finding is introduced or materially worsened by the diff.
+6. Describe a concrete failure scenario and a practical correction direction.
+7. Verify tests protect the changed behavior and that validation evidence matches the risk.
+8. Look for accidental scope expansion, unrelated modernization, PackageId/namespace/path confusion, or workflow assumptions that do not match this repository.
+
+# Severity
+
+- **P0 - Blocker:** data loss, critical security failure, unusable package, or unavoidable broad breakage.
+- **P1 - High:** likely functional bug, unintended breaking change, concurrency/global-state failure, meaningful vulnerability, or incorrect release/package behavior.
+- **P2 - Medium:** real defect in a limited scenario, missing tests for important behavior, or significant maintainability/performance risk.
+- **P3 - Low:** objective improvement that should not block merge by itself.
+
+Do not assign high severity to style preferences already handled by `.editorconfig`, analyzers, or formatting tools.
+
+# Finding Format
+
+Lead with findings. For each one include severity, file/line, problematic behavior, failure scenario, and correction direction. If no issues are found, say so clearly and mention any residual validation gaps.
+
+# Dapper-FluentMap Review Focus
+
+- Does the diff preserve explicit mapping > convention > Dapper default precedence?
+- Does it keep normal Dapper queries distinct from FluentMap-controlled materialization paths?
+- Are global static configuration and `SqlMapper.SetTypeMap` effects isolated in tests?
+- Are nested/value-object claims proven end to end, not just by metadata?
+- Do package changes account for all five NuGet packages and independent identities?
+- Do release/workflow changes preserve `master`, version validation, artifact checks, provenance, and recovery behavior?
+
+# Restrictions
+
+- Do not rewrite the PR from preference.
+- Do not require a new abstraction without a concrete failure or maintenance risk.
+- Do not mark pre-existing unrelated behavior as a regression unless the diff materially increases risk.
+- Do not approve a risky PR merely because it builds.
+
+# Quality Bar
+
+A good review prioritizes a small number of real, reproducible issues, explains impact clearly, and uses deterministic validation as evidence when possible.

--- a/.agents/skills/dotnet-refactoring-engineer/SKILL.md
+++ b/.agents/skills/dotnet-refactoring-engineer/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: dotnet-refactoring-engineer
+description: Use this skill to review or refactor C#/.NET code in Dapper-FluentMap for clarity, cohesion, testability, performance, or maintainability while preserving observable behavior and public API. Do not use for purely cosmetic rewrites.
+license: MIT
+---
+
+# Purpose
+
+Guide safe, incremental refactoring in Dapper-FluentMap without accidental functional changes, public API breaks, or package/release side effects.
+
+# When To Use
+
+- Reducing real duplication or coupling.
+- Clarifying names, responsibilities, control flow, or tests.
+- Improving performance or allocation behavior without changing semantics.
+- Preparing a later change while keeping current behavior stable.
+- Isolating global state, cache, reflection, expression parsing, or Dapper integration concerns.
+
+# When Not To Use
+
+- A functional production change is the main task: use `dotnet-library-change`.
+- CI/CD, packaging, versioning, or release is the main task: use `ci-release-governance`.
+- A PR/diff review is requested: use `dotnet-pr-review`.
+- The change is only documentation or agent governance.
+
+# Process
+
+1. Read root `AGENTS.md`, target code, and related tests.
+2. State the concrete design or maintenance problem being solved.
+3. Identify observable behavior and public contracts that must remain stable.
+4. Check existing test coverage before touching high-risk areas.
+5. Add characterization tests first when behavior is not sufficiently protected.
+6. Apply the smallest refactor with clear benefit.
+7. Avoid public signature changes, project/PackageId changes, dependency changes, broad formatting, or unrelated renames.
+8. Review the diff for unintended behavior change, compatibility impact, global-state changes, cache-key changes, or packaging side effects.
+9. Run the nearest validation from `AGENTS.md`.
+
+# Dapper-FluentMap Hot Spots
+
+- `FluentMapper.Initialize`, static configuration, and Dapper `SqlMapper.SetTypeMap`.
+- Type maps, member maps, constructor binding, naming policies, conventions, profiles, converters, and generated materializer fallback.
+- Expression parsing for converted, inherited, nested, or ambiguous members.
+- Cache keys and invalidation involving entity type, profile, column name, naming policy, and comparison rules.
+- Dommel integration only when the refactor explicitly touches shared core contracts it consumes.
+
+# Restrictions
+
+- Do not make methods, properties, or types public just to test them.
+- Do not simplify by changing documented or observable behavior.
+- Do not introduce abstractions, patterns, dependencies, or frameworks without a concrete local payoff.
+- Do not remove or weaken tests, warnings, analyzers, or diagnostics.
+- Do not use broad formatting or solution-wide cleanup unless that is the explicit task.
+
+# Quality Bar
+
+A good refactor reduces complexity or improves clarity in the requested area, preserves source/binary/behavior compatibility, keeps the diff focused, and remains covered by meaningful tests.

--- a/.agents/skills/microbenchmarking/SKILL.md
+++ b/.agents/skills/microbenchmarking/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: microbenchmarking
+description: >
+  Activate when BenchmarkDotNet is involved or when a .NET performance question requires controlled microbenchmark measurement. Covers benchmark design, BDN configuration, project setup, cost-aware execution, side-by-side comparisons, diagnostics, and interpretation. Do not use for profiling/tracing, production telemetry, or load/stress testing.
+license: MIT
+---
+
+# Benchmark Authoring Guidelines
+
+BenchmarkDotNet (BDN) is the default tool for controlled .NET microbenchmarks in this skill.
+
+> **Dapper-FluentMap integration:** prefer the existing `benchmarks/Dapper.FluentMap.Benchmarks` project. Preserve repository dependency/versioning conventions as they actually exist; this repository currently uses explicit `PackageReference` versions rather than Central Package Management. Do not introduce CPM as incidental benchmark work. Benchmark changes must not alter public behavior merely to improve measurements.
+
+## Benchmarks are comparative instruments
+
+A single number has limited value. Identify the comparison axis first:
+
+- mapping approaches;
+- current vs candidate implementation;
+- runtime/package versions;
+- reflection/runtime mapping vs generated paths;
+- input scale;
+- allocation behavior;
+- historical measurements.
+
+See [references/comparison-strategies.md](references/comparison-strategies.md) before configuring non-trivial comparisons.
+
+## Benchmark lifecycle
+
+Choose the use case before creating code:
+
+1. **Coverage suite** — permanent representative benchmarks.
+2. **Issue investigation** — task-scoped reproduction of a performance problem.
+3. **Change validation** — before/after validation for a PR.
+4. **Development feedback** — temporary experiment.
+
+Only permanent coverage-suite benchmarks should automatically become repository code. Temporary experiments should remain isolated unless explicitly requested.
+
+## Cost awareness
+
+Each BDN case has real wall-clock cost. `[Params]` creates Cartesian products and multiple jobs multiply the case count.
+
+| Preset | Typical purpose |
+|---|---|
+| `--job Dry` | correctness/compilation validation |
+| `--job Short` | quick development measurements |
+| default | final normal measurements |
+| `--job Medium` | higher confidence |
+| `--job Long` | exceptional high-confidence runs |
+
+Always estimate method × parameter × job case count before a large run.
+
+## Running benchmarks
+
+Inspect the current benchmark entry point before assuming CLI forwarding. Use a narrow filter and redirect verbose output:
+
+```bash
+dotnet run --project ./benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj -c Release -- --filter "*MethodName" --noOverwrite > benchmark.log 2>&1
+```
+
+Run a dry representative case before longer measurements.
+
+## Writing new benchmarks
+
+Determine the real caller scenario, comparison axis, input shape, setup/reset needs, parameter count, and whether allocation diagnostics matter.
+
+Key invariants:
+
+- return results when needed to prevent dead-code elimination;
+- move initialization to `[GlobalSetup]`;
+- do not add manual loops merely to increase measurement work;
+- mark an explicit baseline;
+- store inputs in fields/params rather than foldable constants;
+- use seeded randomness for reproducibility;
+- materialize deferred execution when execution is what should be measured;
+- isolate global FluentMap/Dapper configuration so one case does not contaminate another.
+
+See [references/writing-benchmarks.md](references/writing-benchmarks.md).
+
+## Dependency/setup rule
+
+BenchmarkDotNet is already present in the repository benchmark project. Do not add another benchmark project or change dependency-management strategy unless the task demonstrates a need. If dependency versions change, follow the repository's existing package-version conventions and validate the benchmark project explicitly.
+
+## Diagnostics
+
+Use [references/diagnosers-and-exporters.md](references/diagnosers-and-exporters.md) when timing alone is insufficient. Allocation data can be especially relevant for a mapping library.
+
+## Validation
+
+1. Build the benchmark project in Release.
+2. Run a dry representative case.
+3. Run a narrow real measurement.
+4. Confirm baseline and input set.
+5. Read generated Markdown/CSV results.
+6. Report runtime, hardware/OS and statistical limitations.
+7. Do not treat tiny differences inside measurement noise as meaningful regressions/improvements.

--- a/.agents/skills/microbenchmarking/references/bdn-internals-and-tuning.md
+++ b/.agents/skills/microbenchmarking/references/bdn-internals-and-tuning.md
@@ -1,0 +1,50 @@
+# BenchmarkDotNet Execution and Configuration
+
+## Build and execution
+
+BDN generates a standalone project containing the measurement harness, builds it once per unique build configuration, and runs each case in its own process. Cases are partitioned into separate builds when they differ in runtime, toolchain, platform, JIT, GC settings, build configuration, or MSBuild arguments.
+
+`[Params]` creates a Cartesian product: methods × parameter combinations × jobs. Estimate this before running a full suite.
+
+## Execution stages per case
+
+Typical throughput runs include:
+
+1. **Process launch + JIT** — initial compilation is excluded from steady-state results.
+2. **Pilot** — BDN calibrates invocation count per iteration.
+3. **Warmup** — runtime/JIT reaches stable behavior.
+4. **Actual** — measured iterations used for statistics.
+
+Exact defaults can change across BDN versions; prefer the installed package's behavior over assumptions from memory.
+
+## Job presets
+
+| Preset | Purpose |
+|---|---|
+| `Dry` | validate compilation/execution, not performance |
+| `Short` | fast development feedback |
+| Default | normal steady-state measurement |
+| `Medium` | higher confidence |
+| `Long` | expensive, high-confidence runs |
+
+## Run strategies
+
+- **Throughput** — steady-state microbenchmarking; normal default.
+- **ColdStart** — first-call/startup behavior; measured invocation includes startup/JIT effects.
+- **Monitoring** — macro-style single-invocation measurement with configurable warmup.
+
+## Jobs and mutators
+
+A job defines a complete run configuration. Mutators such as warmup or iteration attributes alter each applicable job rather than creating an independent comparison job.
+
+Common controls include warmup count, iteration count, invocation count, iteration time, launch count, target runtime, environment variables, and GC mode. Do not fix them without a reason; BDN adaptive defaults are usually safer than arbitrary manual tuning.
+
+## Unroll factor
+
+BDN may unroll benchmark invocations internally to reduce harness overhead. `UnrollFactor` is engine configuration; `OperationsPerInvoke` declares that one benchmark invocation performs multiple logical operations. They solve different problems.
+
+When `[IterationSetup]` or `[IterationCleanup]` is used, BDN normally shifts toward single-invocation iterations. That can make very fast operations noisy; prefer `[GlobalSetup]` where possible.
+
+## Execution environment
+
+Multiple runtimes, GC settings, or environment-variable configurations create distinct jobs and multiply total run cost. Use them only when they are the actual comparison axis.

--- a/.agents/skills/microbenchmarking/references/comparison-strategies.md
+++ b/.agents/skills/microbenchmarking/references/comparison-strategies.md
@@ -1,0 +1,46 @@
+# Comparing benchmark results
+
+BenchmarkDotNet is most useful when alternatives are measured side-by-side under controlled conditions.
+
+## Strategy 1: Side-by-side methods
+
+When old/new implementations can coexist, define separate benchmark methods and mark one baseline:
+
+```csharp
+[Benchmark(Baseline = true)]
+public int Baseline() => ExistingImplementation();
+
+[Benchmark]
+public int Candidate() => CandidateImplementation();
+```
+
+## Strategy 2: Comparing runtimes
+
+Use multiple target frameworks/jobs only when runtime version is the comparison axis. Multi-runtime BDN runs require the benchmark project to target all compared TFMs.
+
+## Strategy 3: Comparing NuGet package versions
+
+Use an MSBuild property or repository-supported mechanism to vary dependency version per job. Preserve the repository's current dependency-versioning model rather than introducing a new one merely for a benchmark.
+
+## Strategy 4: Saved build vs current source
+
+For before/after comparisons without published packages, a saved baseline DLL can be referenced by one BDN job while another job references current source. Keep namespace/API compatibility identical so the benchmark itself is not changing between jobs.
+
+## Strategy 5: Runtime configuration
+
+Use multiple jobs to compare GC/JIT/runtime settings when configuration itself is under investigation. Mark exactly one job as baseline.
+
+## Strategy 6: Input scale
+
+Use `[Params]` or equivalent parameter sources to evaluate scaling behavior. Prefer a small, intentional set of representative sizes; avoid accidental Cartesian explosions.
+
+## Baselines
+
+- Method comparison: use `[Benchmark(Baseline = true)]`.
+- Multi-job comparison: mark one job with `.AsBaseline()`.
+
+Without a baseline, BDN reports absolute values but no useful ratio column.
+
+## Statistical interpretation
+
+A small numeric difference is not automatically meaningful. Consider variance/error and, when useful, add an explicit equivalence threshold so results can be classified as faster/same/slower instead of over-interpreting noise.

--- a/.agents/skills/microbenchmarking/references/diagnosers-and-exporters.md
+++ b/.agents/skills/microbenchmarking/references/diagnosers-and-exporters.md
@@ -1,0 +1,42 @@
+# Measurement and diagnostics
+
+BenchmarkDotNet measures wall-clock time by default. Add diagnosers only when they answer the performance question.
+
+## MemoryDiagnoser
+
+Use `[MemoryDiagnoser]`, config APIs, or `--memory` to track managed allocations and GC activity per operation. Allocation differences can be more actionable than tiny timing differences in library code.
+
+## DisassemblyDiagnoser
+
+Use disassembly when JIT/codegen behavior is part of the hypothesis. It can produce assembly reports and optional source mapping.
+
+## ThreadingDiagnoser
+
+Use threading diagnostics for lock contention and work-item behavior when concurrency overhead is relevant.
+
+## EventPipeProfiler
+
+EventPipe can collect cross-platform CPU/GC/JIT traces. Profiling changes run cost and can add overhead; do not treat profiled timing as equivalent to an unprofiled benchmark unless configuration isolates profiling from measurement.
+
+## Hardware counters
+
+Hardware counters are platform/hardware dependent and may require elevated permissions. Use them only when cache/branch/CPU-counter evidence is necessary.
+
+## Statistical output
+
+Common BDN columns include:
+
+| Column | Meaning |
+|---|---|
+| `Mean` | average per-operation time |
+| `Error` | confidence-interval signal |
+| `StdDev` | measurement spread |
+| `Median` | central value less sensitive to skew |
+| `Ratio` | current/baseline performance when a baseline exists |
+| `Allocated` | bytes allocated per operation when memory diagnostics are enabled |
+
+Do not report a small `Mean` delta without considering error/variance and practical size.
+
+## Export formats
+
+Prefer generated GitHub Markdown and CSV for human review. Add JSON only when programmatic comparison requires structured output.

--- a/.agents/skills/microbenchmarking/references/project-setup-and-running.md
+++ b/.agents/skills/microbenchmarking/references/project-setup-and-running.md
@@ -1,0 +1,50 @@
+# Running benchmarks
+
+This reference covers how to build, run, and read BenchmarkDotNet results.
+
+## Entry points
+
+**BenchmarkSwitcher** forwards CLI arguments and otherwise can prompt interactively. Agents should always provide `--filter` to avoid hanging:
+
+```csharp
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+```
+
+**BenchmarkRunner** honors CLI args only when an overload receives them. Check the current entry point before assuming flags work.
+
+## Existing benchmark project
+
+Prefer `benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj`. Create another benchmark project only when the existing project cannot represent the requested measurement.
+
+## Build and run strategy
+
+```bash
+dotnet build ./benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj -c Release
+dotnet run --project ./benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj -c Release --no-build -- --filter "*MethodName" --noOverwrite > benchmark.log 2>&1
+```
+
+Read generated Markdown reports first; inspect the verbose log only for errors or unexpected behavior.
+
+## Useful CLI flags
+
+| Flag | Purpose |
+|---|---|
+| `--filter "*"` | run all benchmarks without interactive prompt |
+| `--filter "*MethodName"` | run a focused method set |
+| `--list flat` | list discoverable benchmark names |
+| `--job Dry` | validate compilation/execution quickly |
+| `--job Short` | development measurement |
+| `--artifacts ./path` | control result location |
+| `--noOverwrite` | preserve previous result files |
+| `--exporters json` | add JSON output when needed |
+| `--keepFiles` | retain generated project for build diagnosis |
+
+## Dry-run validation
+
+Always validate setup before a full benchmark suite:
+
+```bash
+dotnet run --project ./benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj -c Release --no-build -- --filter "*" --job Dry --noOverwrite
+```
+
+A dry run proves setup/compilation/execution, not performance.

--- a/.agents/skills/microbenchmarking/references/writing-benchmarks.md
+++ b/.agents/skills/microbenchmarking/references/writing-benchmarks.md
@@ -1,0 +1,61 @@
+# Benchmark authoring techniques
+
+Incorrect benchmarks can silently produce misleading results. Use these invariants when authoring BenchmarkDotNet code.
+
+## Dead code elimination
+
+Return a computed result when needed so the JIT cannot eliminate the work:
+
+```csharp
+[Benchmark]
+public int Parse() => int.Parse(_value);
+```
+
+Operations with observable side effects do not need an artificial return solely for DCE prevention.
+
+## Setup and cleanup
+
+Use `[GlobalSetup]` for data/configuration that should not be measured. Use `[IterationSetup]` only when state must be reset between iterations; it can force single-invocation behavior and make very fast operations noisy.
+
+For FluentMap benchmarks, reset or isolate global mapper/Dapper configuration so one benchmark case cannot contaminate another.
+
+## OperationsPerInvoke
+
+Use `OperationsPerInvoke` only when a single benchmark invocation intentionally performs multiple logical operations whose setup cannot be moved out. Do not add manual loops merely to make a benchmark take longer.
+
+## No accidental state growth
+
+Benchmark methods should have stable performance characteristics across invocations. If the operation mutates state, reset that state intentionally outside measured work where possible.
+
+## Async benchmarks
+
+BDN supports `Task`, `Task<T>`, `ValueTask`, and `ValueTask<T>` benchmark methods. Do not wrap synchronous operations in fake async code because state-machine overhead becomes part of the measurement.
+
+## Deferred execution
+
+Returning an unmaterialized `IEnumerable<T>` can benchmark query creation instead of execution. Materialize or consume deferred sequences when execution is the intended measurement.
+
+## Constant folding
+
+Do not benchmark literals/`const` inputs that the JIT can precompute. Store inputs in fields, `[Params]`, or argument sources.
+
+## Randomness and reproducibility
+
+Use fixed seeds for generated benchmark data unless randomness itself is under investigation.
+
+## Parameterization
+
+Use `[Params]`, `[ParamsSource]`, `[Arguments]`, `[ArgumentsSource]`, and generic type arguments intentionally. Parameter dimensions multiply case count.
+
+If different benchmarks need materially different parameter spaces, prefer separate classes rather than a large Cartesian product.
+
+## Validation checklist
+
+- [ ] Setup work is outside measured code unless intentionally measured
+- [ ] Results/work cannot be optimized away
+- [ ] Deferred execution is actually executed
+- [ ] Inputs are not accidentally constant-folded
+- [ ] Random data is reproducible
+- [ ] Global mapping state is isolated/reset
+- [ ] Parameter/job count is intentional
+- [ ] A comparison has a clear baseline

--- a/.agents/skills/nuget-trusted-publishing/SKILL.md
+++ b/.agents/skills/nuget-trusted-publishing/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: nuget-trusted-publishing
+description: >
+  Review, maintain, or set up NuGet trusted publishing (OIDC) for GitHub Actions. USE FOR: NuGet OIDC, keyless NuGet publish, NuGet/login, trusted-publishing policy changes, release authentication, and diagnosing NuGet trusted-publishing failures. DO NOT USE FOR: private feeds that do not support nuget.org trusted publishing.
+license: MIT
+---
+
+# NuGet Trusted Publishing
+
+Use NuGet trusted publishing to exchange GitHub OIDC identity for a short-lived NuGet API key instead of storing a long-lived publishing key.
+
+> **Dapper-FluentMap baseline:** trusted publishing is already implemented in `.github/workflows/release.yml` through `NuGet/login`, a protected `release` environment, and job-scoped `id-token: write`. Treat that implementation as the baseline to preserve and review, not something to recreate from a generic sample. `AGENTS.md`, `eng/package-catalog.json`, `eng/publish-package-set.ps1`, release recovery, and package immutability rules are authoritative.
+
+## When to Use
+
+- Reviewing or changing the NuGet.org publishing job.
+- Diagnosing `NuGet/login`, OIDC, policy, environment, or authorization failures.
+- Adding a new package to the governed package family.
+- Changing the release workflow filename or GitHub Environment in a way that may affect the nuget.org trusted-publishing policy.
+- Verifying that release changes preserve short-lived credentials and least privilege.
+
+## Safety Rules
+
+- Never replace OIDC with a long-lived NuGet API key merely to make a release pass.
+- Never publish, tag, create a GitHub Release, or invoke recovery unless the user explicitly requests it.
+- Package IDs and published versions are immutable release identities; validate before publishing.
+- A NuGet.org flat-container `404` proves only that a package/version is not currently present. It does not prove that the publisher is authorized to create that PackageId.
+- Preserve partial-release recovery: validate existing registry artifacts and publish only missing artifacts rather than deleting or overwriting package versions.
+
+## Repository Assessment
+
+Before changing trusted publishing, inspect:
+
+1. `.github/workflows/release.yml` and `release-recovery-missing-nuget.yml`.
+2. `eng/package-catalog.json` for the exact five governed PackageIds.
+3. `eng/publish-package-set.ps1` for publication/idempotency behavior.
+4. `eng/validate-release-artifacts.ps1` and consumer-smoke validation.
+5. The `release` environment and the exact nuget.org trusted-publishing policy values when external configuration is involved.
+
+Current governed package family:
+
+- `Dapper.FluentMap`
+- `Dapper.FluentMap.Dommel`
+- `FluentMap.DependencyInjection`
+- `FluentMap.Analyzers`
+- `FluentMap.Generators`
+
+Project identity, assembly identity, namespace identity, and NuGet `PackageId` are independent. Do not rename projects/assemblies/namespaces as a side effect of a publishing change.
+
+## Trusted Publishing Pattern
+
+The NuGet publishing job should retain the equivalent of:
+
+```yaml
+permissions:
+  contents: read
+  id-token: write
+
+- name: Exchange GitHub OIDC token for temporary NuGet API key
+  id: nuget-login
+  uses: NuGet/login@<approved-pinned-sha>
+  with:
+    user: "${{ vars.NUGET_USER }}"
+```
+
+The temporary key is then passed only to the governed publication step. Keep `NuGet/login` SHA-pinned according to repository policy.
+
+## Policy Coupling
+
+The nuget.org trusted-publishing policy is coupled to GitHub identity. Changes to these values may require external policy updates:
+
+- repository owner/name;
+- publishing workflow filename;
+- GitHub Environment name;
+- nuget.org account/package ownership.
+
+Do not claim external policy changes are complete unless they are verified.
+
+## Validation
+
+For code-only release changes, validate the existing deterministic release pipeline rather than performing a real publish:
+
+- workflow schema/actionlint where applicable;
+- restore/build/test/pack;
+- package metadata and artifact-manifest validation;
+- consumer-smoke tests;
+- package catalog consistency;
+- least-privilege permissions and OIDC path.
+
+A real publish is required only when the user explicitly asks for release execution.
+
+## Troubleshooting
+
+| Problem | Likely cause | Check |
+|---|---|---|
+| `NuGet/login` 403 | OIDC permission/policy mismatch | `id-token: write`, policy repo/workflow/environment |
+| No matching policy | Workflow/environment identity mismatch | Exact nuget.org policy values |
+| Push unauthorized | Package ownership/policy authorization | Package owner/publisher configuration |
+| Temporary key expired | Login too early | Move token exchange close to publication |
+| Package already exists | Re-run/partial release | Validate existing artifact and publish only missing packages |
+
+## References
+
+- [references/package-types.md](references/package-types.md)
+- [references/publish-workflow.md](references/publish-workflow.md)
+- [NuGet Trusted Publishing](https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing)

--- a/.agents/skills/nuget-trusted-publishing/references/package-types.md
+++ b/.agents/skills/nuget-trusted-publishing/references/package-types.md
@@ -1,0 +1,46 @@
+# NuGet Package Type Reference
+
+Structural requirements for each NuGet package type. Use this to validate packaging setup before changing trusted publishing.
+
+## Detection Logic
+
+Inspect `.csproj` files and shared MSBuild properties:
+
+```text
+1. Has <PackageType>Template</PackageType>?             → Template package
+2. Has <PackageType>McpServer</PackageType>?           → MCP server
+3. Has <PackAsTool>true</PackAsTool>?                  → Dotnet tool
+4. Has <IsPackable>true</IsPackable> or no OutputType? → NuGet library
+5. Has <OutputType>Exe</OutputType> + IsPackable=true? → Application package
+6. Executable without PackAsTool/IsPackable?           → Not packable by default
+```
+
+## NuGet Library
+
+Common metadata includes `PackageId`, version, authors, description, tags, README, SPDX license, repository URL, Source Link, and symbol-package configuration. Inspect repository-wide metadata before assuming a project is incomplete.
+
+### Including README in Package
+
+`PackageReadmeFile` alone is not enough; the file also needs to be packed:
+
+```xml
+<PropertyGroup>
+  <PackageReadmeFile>README.md</PackageReadmeFile>
+</PropertyGroup>
+<ItemGroup>
+  <None Include="README.md" Pack="true" PackagePath="/" />
+</ItemGroup>
+```
+
+## Dapper-FluentMap package family
+
+This repository publishes libraries/analyzer packages. `eng/package-catalog.json` is authoritative for project-to-PackageId mapping. Do not infer PackageId from project name, assembly name, or namespace.
+
+## Common Gotchas
+
+- Class libraries are normally packable; console apps normally are not unless configured.
+- Shared package metadata may live in `Directory.Build.props`.
+- This repository currently uses explicit `PackageReference` versions in projects; do not assume Central Package Management.
+- Multi-project repositories may publish multiple packages from one governed release workflow.
+- Prefer explicit pack, metadata validation, release-artifact validation, and consumer-smoke verification before publication.
+- Package IDs and published versions are effectively permanent; validate before push.

--- a/.agents/skills/nuget-trusted-publishing/references/publish-workflow.md
+++ b/.agents/skills/nuget-trusted-publishing/references/publish-workflow.md
@@ -1,0 +1,44 @@
+# Publish Workflow Reference
+
+Reference pattern for NuGet trusted publishing. Adapt it to the repository's existing release workflow instead of replacing governance wholesale.
+
+## Core Pattern
+
+```yaml
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@<approved-pinned-sha>
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@<approved-pinned-sha>
+
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@<approved-pinned-sha>
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push to NuGet
+        run: >
+          dotnet nuget push ./artifacts/*.nupkg
+          --api-key ${{ steps.login.outputs.NUGET_API_KEY }}
+          --source https://api.nuget.org/v3/index.json
+```
+
+## Dapper-FluentMap Adaptation Rules
+
+- Preserve the existing `.github/workflows/release.yml` flow rather than replacing it with this sample.
+- Preserve version derivation, package catalog, artifact checksums, release metadata, Source Link/symbol package checks, consumer smoke tests, GitHub Packages publication, GitHub Release behavior, and recovery semantics.
+- Preserve `NuGet/login` OIDC, the protected `release` environment, least-privilege permissions, and SHA-pinned actions.
+- Use the exact workflow filename/environment in the nuget.org trusted-publishing policy.
+- Normal PR CI does not need `id-token: write`.
+- Do not re-tag or reuse a package version after publication errors.
+- On partial releases, validate existing package contents and publish only missing packages; do not delete registry artifacts as rollback.

--- a/.agents/skills/test-gap-analysis/SKILL.md
+++ b/.agents/skills/test-gap-analysis/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: test-gap-analysis
+description: >-
+  Pseudo-mutation analysis for behavioral blind spots: determine whether existing tests would catch meaningful caller-visible production changes, identify survivors or untested outcomes, and optionally close verified gaps with focused tests. Use for behavioral gaps and missing edge cases. Use coverage-analysis when available for project-wide coverage arithmetic and test-anti-patterns when available for broad test-quality smells.
+license: MIT
+---
+
+# Test Gap Analysis
+
+Answer one question: **which caller-visible production behaviors could change without an existing test failing?** Mutation reasoning is a probe, not the goal. Inventory public outcomes first, then verify only credible gaps.
+
+> **Dapper-FluentMap integration:** preserve public compatibility and use the repository's existing test layers. Prefer `test/Dapper.FluentMap.Tests` for focused core behavior, provider/integration suites for materialization behavior, Roslyn tests for analyzers/generators, and `eng/consumer-smoke` for package-consumer behavior. Do not mutate global Dapper/FluentMap state without restoring it.
+
+## Decision flow
+
+### 1. Set scope
+
+Discover production and test files from `Dapper.FluentMap.slnx` and the existing test layout. Keep a focused request focused.
+
+| Request | Action |
+|---|---|
+| One component or named risk | Inventory every high-risk public outcome in scope; do not edit production code unless verification was requested |
+| General small-component review | Inventory distinct outcomes and report caller-visible gaps from source/assertion mapping |
+| Explicit survivor verification | Execute one representative observable candidate for each distinct high-risk outcome under verification |
+| Explicit exhaustive audit | Read [references/mutation-catalog.md](references/mutation-catalog.md) and classify all meaningful candidates |
+| Add tests to an existing suite | Analyze first; add tests only for verified survivors or demonstrated no-coverage outcomes |
+
+### 2. Establish one baseline
+
+Run the narrowest existing test command once and confirm tests actually executed. For core behavior, normally start with:
+
+```bash
+dotnet test ./test/Dapper.FluentMap.Tests/Dapper.FluentMap.Tests.csproj --configuration Release
+```
+
+If the suite cannot run, continue statically and label executable mutation candidates **unverified**.
+
+### 3. Inventory public outcomes
+
+For each public entry point, map:
+
+- input partitions and guard boundaries;
+- returns/results/exceptions/state transitions/side effects;
+- mapping precedence and fallback behavior;
+- case sensitivity, duplicate registration, conventions and caches when relevant;
+- Dapper materialization or Dommel behavior only through real caller-visible outcomes;
+- analyzer/generator diagnostics and generated output when relevant.
+
+Use:
+
+```text
+public input/sequence -> expected outcome -> existing assertion -> gap
+```
+
+One asserted field does not cover another. Unit metadata tests do not prove end-to-end Dapper materialization.
+
+### 4. Admit only observable candidates
+
+Before reporting a candidate, replay it against existing asserted inputs. If an assertion observes the changed result, it is **Likely killed** and not a gap.
+
+For survivors, state:
+
+```text
+witness -> original observation -> mutant observation
+```
+
+Exclude generated code, formatting/logging-only changes unless contractual, non-compiling edits, equivalent mutations, impossible domain values, trivial forwarding members, and private representation changes callers cannot distinguish.
+
+### 5. Rank and classify
+
+Prioritize:
+
+1. public compatibility, mapping correctness, package-consumer behavior, data correctness and error semantics;
+2. wholly unasserted public outcomes;
+3. exact boundaries/precedence/case behavior reached only by weak assertions;
+4. alternate variants of already-protected behavior.
+
+Use these labels:
+
+| Result | Meaning |
+|---|---|
+| **Likely killed** | An existing assertion observes the changed outcome |
+| **Candidate survivor (unverified)** | Observable change appears unasserted; not executed |
+| **Survived** | Exact observable mutation executed and tests stayed green |
+| **No coverage** | No test reaches the public outcome |
+| **Equivalent** | No public observation changes; omit from findings |
+
+Verdict: **Strong**, **Mixed**, or **Weak**.
+
+### 6. Verify safely when requested
+
+1. Apply one temporary candidate and confirm the diff changes exactly one intended expression.
+2. Run the narrowest covering tests.
+3. Green = **Survived**; red = **Killed**, for that edit only.
+4. Revert immediately and confirm the source baseline is clean.
+5. Never commit temporary mutations.
+6. Restore global FluentMap/Dapper state in tests that alter it.
+
+### 7. Close gaps only when requested
+
+- Add focused behavior tests only for demonstrated gaps.
+- Prefer tests that protect a caller-visible contract over tests that merely inflate coverage.
+- Use integration/provider tests when the risk concerns actual Dapper materialization.
+- Use package/consumer-smoke validation when the risk concerns package identity, analyzers/generators, trimming, or installation.
+
+## Output contract
+
+For focused analysis return one-line verdict, a short strengths sentence, then one compact row per actionable gap:
+
+| Risk | Public outcome | Change | Result/evidence | Smallest test |
+|---|---|---|---|---|
+
+Every gap needs a distinguishing witness and a concrete smallest test.
+
+## Reliability rules
+
+- A passing test that does not assert the changed outcome does not kill a mutation.
+- Coverage is per behavior partition, not merely per executed line.
+- Never recommend a redundant test for behavior already protected.
+- `AGENTS.md`, repository compatibility rules, and deterministic validation prevail over this skill.

--- a/.agents/skills/test-gap-analysis/references/mutation-catalog.md
+++ b/.agents/skills/test-gap-analysis/references/mutation-catalog.md
@@ -1,0 +1,43 @@
+# Mutation Candidate Catalog
+
+Read this reference only for an explicitly exhaustive audit or when mutation semantics are unfamiliar. For focused analysis, use the smaller risk-ranked workflow in `SKILL.md`.
+
+## Candidate categories
+
+| Category | Typical changes | What a killing test must observe |
+|---|---|---|
+| Boundary | `<` ↔ `<=`, `>` ↔ `>=`, zero/one, first/last index | Exact value at and immediately around the boundary |
+| Boolean/logic | `&&` ↔ `||`, negate/remove one condition, `true` ↔ `false` | Each condition independently changes asserted behavior |
+| Return value | value ↔ default/empty/null, true ↔ false, count ±1 | The returned value or downstream state |
+| Error/guard | remove guard, change exception/error type, swallow propagation | Invalid input and exact observable error semantics |
+| Arithmetic | `+` ↔ `-`, `*` ↔ `/`, sign flip, increment ↔ decrement | Exact calculated result, not only a broad range |
+| Collection | empty/non-empty, omit first/last item, order reversal | Contents, count, and order where relevant |
+| State transition | skip assignment, retain old state, alter an existing update | Both result and resulting state |
+
+## Dapper-FluentMap-specific candidates
+
+- change explicit mapping vs convention vs Dapper fallback precedence;
+- alter case-sensitive/case-insensitive member resolution;
+- remove duplicate/invalid mapping guards;
+- change `Ignore()` or Dommel-visible metadata behavior;
+- alter cache keys or invalidation behavior;
+- change nested/value-object member resolution;
+- change analyzer diagnostic presence/severity/location;
+- change source-generator output in a way that affects consumer compilation/runtime behavior;
+- change exception type or error propagation;
+- alter async/cancellation behavior where present.
+
+## Equivalence and noise filters
+
+Exclude generated output unless generated behavior itself is the contract under test, logging/formatting-only changes unless contractual, impossible domain values, redundant checks whose removal cannot affect behavior, and private representation changes no public input can distinguish.
+
+## Exhaustive audit procedure
+
+1. Enumerate meaningful candidates by production behavior, not token/operator.
+2. State the public input and different original/mutant observations.
+3. Map each candidate to covering tests and relevant assertions.
+4. Classify obvious killed/equivalent candidates statically.
+5. Execute every candidate that might be reported as **Survived**.
+6. After a green run, re-check that the mutation is publicly observable.
+7. Revert after each run and confirm the clean baseline at the end.
+8. Count only executed or definitively killed/equivalent candidates in totals; disclose omitted scope.

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -6,13 +6,22 @@
       "version": "11.3.0",
       "commands": [
         "dotnet-sonarscanner"
-      ]
+      ],
+      "rollForward": false
     },
     "dotnet-coverage": {
       "version": "18.11.0",
       "commands": [
         "dotnet-coverage"
-      ]
+      ],
+      "rollForward": false
+    },
+    "rodrioliveira.adrguard": {
+      "version": "0.1.8",
+      "commands": [
+        "adr-guard"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
           persist-credentials: false
           show-progress: false
 
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
+        with:
+          global-json-file: global.json
+
+      - name: Restore local .NET tools
+        run: dotnet tool restore
+
       - name: Install configuration validator
         run: python3 -m pip install --disable-pip-version-check check-jsonschema==0.38.0
 
@@ -43,6 +51,12 @@ jobs:
 
       - name: Validate Dependabot configuration
         run: check-jsonschema --builtin-schema vendor.dependabot .github/dependabot.yml
+
+      - name: Validate ADRs
+        run: |
+          dotnet tool run adr-guard check docs/adr
+          dotnet tool run adr-guard index docs/adr
+          git diff --exit-code -- docs/adr
 
   compatibility:
     name: Compatibility (${{ matrix.dapper-lane }}, Dapper ${{ matrix.dapper-version }})
@@ -177,17 +191,20 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          Import-Module './eng/PackageCatalog.psm1' -Force
           $packageDir = './artifacts/packages'
           $nupkgs = @(Get-ChildItem -Path $packageDir -Filter '*.nupkg' -File)
           $snupkgs = @(Get-ChildItem -Path $packageDir -Filter '*.snupkg' -File)
           $unexpected = @($nupkgs + $snupkgs | Where-Object { $_.Name -match '(Tests|Benchmarks|AotSmoke)' })
+          $expectedNupkgCount = @(Get-FluentMapPackages).Count
+          $expectedSnupkgCount = @(Get-FluentMapPackages -WithSymbols).Count
 
-          if ($nupkgs.Count -ne 5) {
-            throw "Expected 5 .nupkg files, found $($nupkgs.Count)."
+          if ($nupkgs.Count -ne $expectedNupkgCount) {
+            throw "Expected $expectedNupkgCount .nupkg files, found $($nupkgs.Count)."
           }
 
-          if ($snupkgs.Count -ne 3) {
-            throw "Expected 3 .snupkg files, found $($snupkgs.Count)."
+          if ($snupkgs.Count -ne $expectedSnupkgCount) {
+            throw "Expected $expectedSnupkgCount .snupkg files, found $($snupkgs.Count)."
           }
 
           if ($unexpected.Count -gt 0) {

--- a/.github/workflows/release-recovery-missing-nuget.yml
+++ b/.github/workflows/release-recovery-missing-nuget.yml
@@ -134,12 +134,15 @@ jobs:
         run: dotnet restore ./Dapper.FluentMap.slnx
 
       - name: Build validated release source
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          VALIDATED_COMMIT: ${{ inputs.validated_commit }}
         run: >-
           dotnet build ./Dapper.FluentMap.slnx
           --configuration Release
           --no-restore
-          -p:Version=${{ inputs.version }}
-          -p:RepositoryCommit=${{ inputs.validated_commit }}
+          -p:Version="$PACKAGE_VERSION"
+          -p:RepositoryCommit="$VALIDATED_COMMIT"
           -p:RepositoryBranch=refs/heads/master
           -p:ContinuousIntegrationBuild=true
 
@@ -147,14 +150,17 @@ jobs:
         run: dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build --no-restore
 
       - name: Pack release packages
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          VALIDATED_COMMIT: ${{ inputs.validated_commit }}
         run: >-
           dotnet pack ./Dapper.FluentMap.slnx
           --configuration Release
           --no-build
           --no-restore
           --output ./artifacts/packages
-          -p:Version=${{ inputs.version }}
-          -p:RepositoryCommit=${{ inputs.validated_commit }}
+          -p:Version="$PACKAGE_VERSION"
+          -p:RepositoryCommit="$VALIDATED_COMMIT"
           -p:RepositoryBranch=refs/heads/master
           -p:ContinuousIntegrationBuild=true
 

--- a/.github/workflows/release-recovery-missing-nuget.yml
+++ b/.github/workflows/release-recovery-missing-nuget.yml
@@ -1,12 +1,20 @@
-name: Recovery - Publish missing NuGet 3.0.0 packages
+name: Recovery - Publish missing NuGet packages
 
-run-name: "Recover missing NuGet 3.0.0 packages"
+run-name: "Recover missing NuGet packages for ${{ inputs.version }}"
 
 on:
   workflow_dispatch:
     inputs:
+      version:
+        description: "Semantic version without the v prefix, for example 3.0.1."
+        required: true
+        type: string
+      validated_commit:
+        description: "Commit SHA that produced the validated release artifacts."
+        required: true
+        type: string
       confirmation:
-        description: "Type PUBLISH-MISSING-3.0.0 to run the one-off recovery"
+        description: "Type PUBLISH-MISSING-NUGET to run the recovery."
         required: true
         type: string
 
@@ -14,7 +22,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: release-recovery-3.0.0
+  group: release-recovery-${{ inputs.version }}
   cancel-in-progress: false
 
 env:
@@ -22,25 +30,23 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "true"
   DOTNET_NOLOGO: "true"
   CI: "true"
-  RECOVERY_VERSION: "3.0.0"
-  # This is the exact commit that produced the partially published 3.0.0 artifacts
-  # in release run 34234097570. Recovery packages must come from the same source.
-  RECOVERY_COMMIT: "758318cce5fc3644a93916978118e24fb7fadb59"
 
 jobs:
   recover-missing-nuget-packages:
     name: Publish only missing NuGet.org packages
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     environment: release
     permissions:
       contents: read
       id-token: write
 
     steps:
-      - name: Validate recovery confirmation
+      - name: Validate recovery request
         shell: bash
         env:
+          VERSION: ${{ inputs.version }}
+          VALIDATED_COMMIT: ${{ inputs.validated_commit }}
           CONFIRMATION: ${{ inputs.confirmation }}
         run: |
           set -euo pipefail
@@ -50,233 +56,177 @@ jobs:
             exit 1
           fi
 
-          if [[ "$CONFIRMATION" != "PUBLISH-MISSING-3.0.0" ]]; then
-            echo "::error::Recovery confirmation did not match PUBLISH-MISSING-3.0.0."
+          if [[ "$CONFIRMATION" != "PUBLISH-MISSING-NUGET" ]]; then
+            echo "::error::Recovery confirmation did not match PUBLISH-MISSING-NUGET."
             exit 1
           fi
 
-      - name: Checkout original 3.0.0 release commit
+          if [[ "$VERSION" == v* ]]; then
+            echo "::error::Enter the semantic version without the 'v' prefix."
+            exit 1
+          fi
+
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$VERSION" =~ $semver ]]; then
+            echo "::error::Invalid semantic version '$VERSION'."
+            exit 1
+          fi
+
+          major="${VERSION%%.*}"
+          if (( major < 3 )); then
+            echo "::error::FluentMap recovery requires major version 3 or later."
+            exit 1
+          fi
+
+          if [[ "$VERSION" == "3.0.0" ]]; then
+            echo "::error::Version 3.0.0 is immutable and must not be recovered from a newer workflow."
+            exit 1
+          fi
+
+          if [[ ! "$VALIDATED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::validated_commit must be a full 40-character commit SHA."
+            exit 1
+          fi
+
+      - name: Checkout validated release commit
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          ref: ${{ env.RECOVERY_COMMIT }}
+          ref: ${{ inputs.validated_commit }}
           fetch-depth: 0
           persist-credentials: false
           show-progress: false
+
+      - name: Verify release tag
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          VALIDATED_COMMIT: ${{ inputs.validated_commit }}
+        run: |
+          set -euo pipefail
+
+          release_tag="v$VERSION"
+          git fetch --tags
+          if ! git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
+            echo "::error::Expected recovery tag '$release_tag' does not exist. Run the normal release workflow for unreleased versions."
+            exit 1
+          fi
+
+          tag_sha="$(git rev-list -n 1 "$release_tag")"
+          if [[ "$tag_sha" != "$VALIDATED_COMMIT" ]]; then
+            echo "::error::Tag '$release_tag' points to $tag_sha instead of validated commit $VALIDATED_COMMIT. Refusing to move the tag."
+            exit 1
+          fi
+
+          echo "Tag '$release_tag' already points to the validated commit."
 
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
           global-json-file: global.json
 
-      - name: Detect packages still missing from NuGet.org
-        id: preflight
-        shell: bash
+      - name: Validate SLNX equivalence
+        shell: pwsh
         run: |
-          set -euo pipefail
-
-          nuget_status() {
-            local package_id="$1"
-            local package_id_lower
-            package_id_lower="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
-            local version_lower
-            version_lower="$(printf '%s' "$RECOVERY_VERSION" | tr '[:upper:]' '[:lower:]')"
-            local package_url="https://api.nuget.org/v3-flatcontainer/$package_id_lower/$version_lower/$package_id_lower.$version_lower.nupkg"
-
-            curl \
-              --silent \
-              --show-error \
-              --location \
-              --proto '=https' \
-              --proto-redir '=https' \
-              --retry 3 \
-              --retry-delay 2 \
-              --retry-all-errors \
-              --connect-timeout 10 \
-              --max-time 30 \
-              --output /dev/null \
-              --write-out '%{http_code}' \
-              "$package_url"
-          }
-
-          # These two packages were successfully published by run 34234097570.
-          for package_id in 'Dapper.FluentMap' 'Dapper.FluentMap.Dommel'; do
-            status="$(nuget_status "$package_id")"
-            if [[ "$status" != "200" ]]; then
-              echo "::error::Expected $package_id $RECOVERY_VERSION to already exist on NuGet.org, but NuGet returned HTTP $status. Refusing recovery."
-              exit 1
-            fi
-            echo "$package_id $RECOVERY_VERSION already exists as expected."
-          done
-
-          targets=(
-            'Dapper.FluentMap.DependencyInjection'
-            'Dapper.FluentMap.Analyzers'
-            'Dapper.FluentMap.Generators'
-          )
-          missing=()
-
-          for package_id in "${targets[@]}"; do
-            status="$(nuget_status "$package_id")"
-            case "$status" in
-              200)
-                echo "$package_id $RECOVERY_VERSION already exists; it will be skipped."
-                ;;
-              404)
-                echo "$package_id $RECOVERY_VERSION is missing and will be published."
-                missing+=("$package_id")
-                ;;
-              *)
-                echo "::error::Unexpected NuGet.org response HTTP $status while checking $package_id $RECOVERY_VERSION. Failing closed."
-                exit 1
-                ;;
-            esac
-          done
-
-          if (( ${#missing[@]} == 0 )); then
-            echo "has_missing=false" >> "$GITHUB_OUTPUT"
-            echo "package_ids=" >> "$GITHUB_OUTPUT"
-            echo "All recovery package IDs already exist on NuGet.org; nothing to publish."
-            exit 0
-          fi
-
-          package_ids="$(IFS=';'; echo "${missing[*]}")"
-          echo "has_missing=true" >> "$GITHUB_OUTPUT"
-          echo "package_ids=$package_ids" >> "$GITHUB_OUTPUT"
-          echo "Missing packages: $package_ids"
+          $ErrorActionPreference = 'Stop'
+          ./eng/validate-slnx-equivalence.ps1
 
       - name: Restore
-        if: steps.preflight.outputs.has_missing == 'true'
-        run: dotnet restore ./Dapper.FluentMap.sln
+        run: dotnet restore ./Dapper.FluentMap.slnx
 
-      - name: Build original 3.0.0 release source
-        if: steps.preflight.outputs.has_missing == 'true'
+      - name: Build validated release source
         run: >-
-          dotnet build ./Dapper.FluentMap.sln
+          dotnet build ./Dapper.FluentMap.slnx
           --configuration Release
           --no-restore
-          -p:Version=${RECOVERY_VERSION}
-          -p:RepositoryCommit=${RECOVERY_COMMIT}
+          -p:Version=${{ inputs.version }}
+          -p:RepositoryCommit=${{ inputs.validated_commit }}
           -p:RepositoryBranch=refs/heads/master
           -p:ContinuousIntegrationBuild=true
 
       - name: Run tests
-        if: steps.preflight.outputs.has_missing == 'true'
-        run: dotnet test ./Dapper.FluentMap.sln --configuration Release --no-build --no-restore
+        run: dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build --no-restore
 
-      - name: Pack recovery packages
-        if: steps.preflight.outputs.has_missing == 'true'
+      - name: Pack release packages
+        run: >-
+          dotnet pack ./Dapper.FluentMap.slnx
+          --configuration Release
+          --no-build
+          --no-restore
+          --output ./artifacts/packages
+          -p:Version=${{ inputs.version }}
+          -p:RepositoryCommit=${{ inputs.validated_commit }}
+          -p:RepositoryBranch=refs/heads/master
+          -p:ContinuousIntegrationBuild=true
+
+      - name: Validate release artifacts and write manifest
         shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_URL: https://github.com/${{ github.repository }}
+          COMMIT: ${{ inputs.validated_commit }}
         run: |
           $ErrorActionPreference = 'Stop'
-          New-Item -ItemType Directory -Force -Path './artifacts/packages' | Out-Null
+          ./eng/validate-release-artifacts.ps1 `
+            -PackageDirectory './artifacts/packages' `
+            -Version $env:PACKAGE_VERSION `
+            -ManifestPath './artifacts/release-metadata/artifact-manifest.json' `
+            -Repository $env:REPOSITORY `
+            -RepositoryUrl $env:REPOSITORY_URL `
+            -Commit $env:COMMIT `
+            -Branch 'refs/heads/master'
 
-          $projects = @(
-            './src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj',
-            './src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj',
-            './src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj'
-          )
+      - name: Consumer smoke test release packages
+        shell: pwsh
+        env:
+          PACKAGE_VERSION: ${{ inputs.version }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./eng/consumer-smoke/run-consumer-smoke.ps1 `
+            -PackageDirectory './artifacts/packages' `
+            -PackageVersion $env:PACKAGE_VERSION
 
-          foreach ($project in $projects) {
-            dotnet pack $project `
-              --configuration Release `
-              --no-build `
-              --no-restore `
-              --output './artifacts/packages' `
-              -p:Version=$env:RECOVERY_VERSION `
-              -p:RepositoryCommit=$env:RECOVERY_COMMIT `
-              -p:RepositoryBranch='refs/heads/master' `
-              -p:ContinuousIntegrationBuild=true
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "Packing failed for $project."
-            }
-          }
-
-          $expected = @(
-            'Dapper.FluentMap.DependencyInjection.3.0.0.nupkg',
-            'Dapper.FluentMap.Analyzers.3.0.0.nupkg',
-            'Dapper.FluentMap.Generators.3.0.0.nupkg'
-          )
-
-          foreach ($file in $expected) {
-            $path = Join-Path './artifacts/packages' $file
-            if (-not (Test-Path -LiteralPath $path)) {
-              throw "Expected recovery package '$file' was not produced."
-            }
-          }
+      - name: Generate and verify checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd ./artifacts
+          {
+            find packages -type f \( -name '*.nupkg' -o -name '*.snupkg' \)
+            find release-metadata -type f -name '*.json'
+          } | sort | xargs sha256sum > ./release-metadata/SHA256SUMS
+          sha256sum --check ./release-metadata/SHA256SUMS
 
       - name: Exchange GitHub OIDC token for temporary NuGet API key
-        if: steps.preflight.outputs.has_missing == 'true'
         id: nuget-login
         uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
         with:
           user: "${{ vars.NUGET_USER }}"
 
-      - name: Publish only packages that are still missing
-        if: steps.preflight.outputs.has_missing == 'true'
+      - name: Publish missing NuGet.org packages
         shell: pwsh
         env:
           NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
-          PACKAGE_IDS: ${{ steps.preflight.outputs.package_ids }}
+          PACKAGE_VERSION: ${{ inputs.version }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $packageIds = $env:PACKAGE_IDS.Split(';', [System.StringSplitOptions]::RemoveEmptyEntries)
+          ./eng/publish-package-set.ps1 `
+            -PackageDirectory './artifacts/packages' `
+            -Version $env:PACKAGE_VERSION `
+            -Source 'https://api.nuget.org/v3/index.json' `
+            -ApiKey $env:NUGET_API_KEY `
+            -Registry NuGetOrg
 
-          foreach ($packageId in $packageIds) {
-            $idLower = $packageId.ToLowerInvariant()
-            $versionLower = $env:RECOVERY_VERSION.ToLowerInvariant()
-            $url = "https://api.nuget.org/v3-flatcontainer/$idLower/$versionLower/$idLower.$versionLower.nupkg"
-
-            $status = (& curl `
-              --silent `
-              --show-error `
-              --location `
-              --proto '=https' `
-              --proto-redir '=https' `
-              --retry 3 `
-              --retry-delay 2 `
-              --retry-all-errors `
-              --connect-timeout 10 `
-              --max-time 30 `
-              --output /dev/null `
-              --write-out '%{http_code}' `
-              $url).Trim()
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "Unable to re-check NuGet.org before publishing $packageId $env:RECOVERY_VERSION."
-            }
-
-            if ($status -eq '200') {
-              Write-Host "$packageId $env:RECOVERY_VERSION appeared on NuGet.org after preflight; skipping it."
-              continue
-            }
-
-            if ($status -ne '404') {
-              throw "Unexpected NuGet.org response HTTP $status for $packageId $env:RECOVERY_VERSION."
-            }
-
-            $package = "./artifacts/packages/$packageId.$env:RECOVERY_VERSION.nupkg"
-            dotnet nuget push $package `
-              --source 'https://api.nuget.org/v3/index.json' `
-              --api-key $env:NUGET_API_KEY
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "Recovery publication failed for $packageId. If NuGet reports a reserved package ID/prefix, the NuGet account still needs authorization for the reserved Dapper prefix before this recovery can succeed."
-            }
-          }
-
-      - name: Verify recovery result
-        if: steps.preflight.outputs.has_missing == 'true'
+      - name: Verify NuGet.org publication state
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
 
-          for package_id in \
-            'Dapper.FluentMap.DependencyInjection' \
-            'Dapper.FluentMap.Analyzers' \
-            'Dapper.FluentMap.Generators'; do
+          version_lower="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')"
+          while IFS= read -r package_id; do
             package_id_lower="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
-            version_lower="$(printf '%s' "$RECOVERY_VERSION" | tr '[:upper:]' '[:lower:]')"
             package_url="https://api.nuget.org/v3-flatcontainer/$package_id_lower/$version_lower/$package_id_lower.$version_lower.nupkg"
 
             status="$(curl \
@@ -295,11 +245,11 @@ jobs:
               "$package_url")"
 
             if [[ "$status" != "200" ]]; then
-              echo "::error::$package_id $RECOVERY_VERSION is not visible on NuGet.org after recovery (HTTP $status)."
+              echo "::error::$package_id $VERSION is not visible on NuGet.org after recovery (HTTP $status)."
               exit 1
             fi
 
-            echo "$package_id $RECOVERY_VERSION is available on NuGet.org."
-          done
+            echo "$package_id $VERSION is visible on NuGet.org."
+          done < <(jq -r '.packages[].packageId' eng/package-catalog.json)
 
-          echo "Recovery completed: all three previously missing 3.0.0 package IDs are now published on NuGet.org."
+          echo "Recovery completed: all expected package IDs are visible on NuGet.org."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,17 +220,6 @@ jobs:
           PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
         run: |
           $ErrorActionPreference = 'Stop'
-
-          Get-ChildItem './eng/consumer-smoke' -Recurse -File |
-            Where-Object { $_.Extension -in @('.csproj', '.ps1') } |
-            ForEach-Object {
-              $content = Get-Content -LiteralPath $_.FullName -Raw
-              $updated = $content.Replace('3.0.1', $env:PACKAGE_VERSION)
-              if ($updated -ne $content) {
-                [System.IO.File]::WriteAllText($_.FullName, $updated, [System.Text.UTF8Encoding]::new($false))
-              }
-            }
-
           ./eng/consumer-smoke/run-consumer-smoke.ps1 `
             -PackageDirectory './artifacts/packages' `
             -PackageVersion $env:PACKAGE_VERSION
@@ -288,6 +277,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      tag-created: ${{ steps.release-tag.outputs.tag_created }}
 
     steps:
       - name: Checkout validated commit
@@ -296,6 +287,7 @@ jobs:
           fetch-depth: 0
 
       - name: Create or verify tag
+        id: release-tag
         shell: bash
         env:
           RELEASE_TAG: ${{ needs.build-and-pack.outputs.release-tag }}
@@ -312,11 +304,13 @@ jobs:
             fi
 
             echo "Tag '$RELEASE_TAG' already exists on the validated commit."
+            echo "tag_created=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           git tag "$RELEASE_TAG" "$VALIDATED_SHA"
           git push origin "refs/tags/$RELEASE_TAG"
+          echo "tag_created=true" >> "$GITHUB_OUTPUT"
 
   publish-nuget:
     name: Publish to NuGet.org
@@ -503,8 +497,9 @@ jobs:
     if: >-
       ${{ always() &&
           needs.build-and-pack.result == 'success' &&
-          (needs.ensure-release-tag.result == 'failure' ||
-           needs.publish-nuget.result == 'failure' ||
+          needs.ensure-release-tag.result == 'success' &&
+          needs.ensure-release-tag.outputs.tag-created == 'true' &&
+          (needs.publish-nuget.result == 'failure' ||
            needs.publish-github-packages.result == 'failure' ||
            needs.github-release.result == 'failure') }}
     needs:
@@ -517,8 +512,6 @@ jobs:
     environment: release
     permissions:
       contents: write
-      packages: write
-      id-token: write
 
     steps:
       - name: Checkout rollback tooling
@@ -527,28 +520,18 @@ jobs:
           persist-credentials: false
           show-progress: false
 
-      - name: Exchange GitHub OIDC token for rollback NuGet API key
-        id: rollback-nuget-login
-        continue-on-error: true
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
-        with:
-          user: "${{ vars.NUGET_USER }}"
-
       - name: Compensate failed release
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
-          NUGET_API_KEY: ${{ steps.rollback-nuget-login.outputs.NUGET_API_KEY }}
           PACKAGE_VERSION: ${{ needs.build-and-pack.outputs.package-version }}
           RELEASE_TAG: ${{ needs.build-and-pack.outputs.release-tag }}
           REPOSITORY: ${{ github.repository }}
-          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           $ErrorActionPreference = 'Stop'
           ./eng/rollback-release.ps1 `
             -Version $env:PACKAGE_VERSION `
             -ReleaseTag $env:RELEASE_TAG `
             -Repository $env:REPOSITORY `
-            -RepositoryOwner $env:REPOSITORY_OWNER `
             -GitHubToken $env:GH_TOKEN `
-            -NuGetApiKey $env:NUGET_API_KEY
+            -DeleteReleaseTag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Semantic version without the v prefix, for example 3.0.0-rc.1 or 3.0.0."
+        description: "Semantic version without the v prefix, for example 3.0.1 or 3.0.1-rc.1."
         required: true
         type: string
 
@@ -50,107 +50,106 @@ jobs:
 
       - name: Validate release version and availability
         id: version
-        shell: bash
+        shell: pwsh
         env:
           VERSION: ${{ inputs.version }}
         run: |
-          set -euo pipefail
+          $ErrorActionPreference = 'Stop'
+          Import-Module './eng/PackageCatalog.psm1' -Force
 
-          if [[ "$GITHUB_REF" != "refs/heads/master" ]]; then
-            echo "::error::Releases must be started from the master branch. Current ref: $GITHUB_REF"
+          if ($env:GITHUB_REF -ne 'refs/heads/master') {
+            Write-Error "Releases must be started from the master branch. Current ref: $env:GITHUB_REF"
             exit 1
-          fi
+          }
 
-          if [[ "$VERSION" == v* ]]; then
-            echo "::error::Enter the semantic version without the 'v' prefix (for example 3.0.0-rc.1)."
+          if ($env:VERSION.StartsWith('v', [System.StringComparison]::OrdinalIgnoreCase)) {
+            Write-Error "Enter the semantic version without the 'v' prefix (for example 3.0.1)."
             exit 1
-          fi
+          }
 
-          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
-          if [[ ! "$VERSION" =~ $semver ]]; then
-            echo "::error::Invalid semantic version '$VERSION'. Expected a value such as 3.0.0-rc.1 or 3.0.0."
+          if ($env:VERSION -notmatch '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$') {
+            Write-Error "Invalid semantic version '$env:VERSION'. Expected a value such as 3.0.1 or 3.0.1-rc.1."
             exit 1
-          fi
+          }
 
-          major="${VERSION%%.*}"
-          if (( major < 3 )); then
-            echo "::error::FluentMap releases from this workflow must use major version 3 or later."
+          $major = [int]($env:VERSION.Split('.')[0])
+          if ($major -lt 3) {
+            Write-Error 'FluentMap releases from this workflow must use major version 3 or later.'
             exit 1
-          fi
+          }
 
-          release_tag="v$VERSION"
-          is_prerelease=false
-          if [[ "$VERSION" == *-* ]]; then
-            is_prerelease=true
-          fi
-
-          echo "Checking whether release tag '$release_tag' already exists..."
-          git fetch --tags --force
-          if git rev-parse -q --verify "refs/tags/$release_tag" >/dev/null; then
-            tag_sha="$(git rev-list -n 1 "$release_tag")"
-            echo "::error::Release tag '$release_tag' already exists and points to $tag_sha. Choose a new version before building."
+          if ($env:VERSION -eq '3.0.0') {
+            Write-Error 'Version 3.0.0 is immutable and must not be recreated by this workflow. Use 3.0.1 or later for the next coherent release.'
             exit 1
-          fi
+          }
 
-          package_ids=(
-            'Dapper.FluentMap'
-            'Dapper.FluentMap.Dommel'
-            'Dapper.FluentMap.DependencyInjection'
-            'Dapper.FluentMap.Analyzers'
-            'Dapper.FluentMap.Generators'
-          )
-          version_lower="$(printf '%s' "$VERSION" | tr '[:upper:]' '[:lower:]')"
-          published_packages=()
+          $releaseTag = "v$env:VERSION"
+          $isPrerelease = if ($env:VERSION.Contains('-')) { 'true' } else { 'false' }
 
-          echo "Checking NuGet.org for version '$VERSION' before build..."
-          for package_id in "${package_ids[@]}"; do
-            package_id_lower="$(printf '%s' "$package_id" | tr '[:upper:]' '[:lower:]')"
-            package_url="https://api.nuget.org/v3-flatcontainer/$package_id_lower/$version_lower/$package_id_lower.$version_lower.nupkg"
-
-            if ! http_status="$(curl \
-              --silent \
-              --show-error \
-              --location \
-              --proto '=https' \
-              --proto-redir '=https' \
-              --retry 3 \
-              --retry-delay 2 \
-              --retry-all-errors \
-              --connect-timeout 10 \
-              --max-time 30 \
-              --output /dev/null \
-              --write-out '%{http_code}' \
-              "$package_url")"; then
-              echo "::error::Unable to verify NuGet.org availability for $package_id $VERSION. Failing closed before build."
+          Write-Host "Checking release tag '$releaseTag'..."
+          git fetch --tags
+          $tagExists = $false
+          & git rev-parse -q --verify "refs/tags/$releaseTag" *> $null
+          if ($LASTEXITCODE -eq 0) {
+            $tagExists = $true
+            $tagSha = (& git rev-list -n 1 $releaseTag).Trim()
+            if ($tagSha -ne $env:GITHUB_SHA) {
+              Write-Error "Release tag '$releaseTag' points to $tagSha instead of validated commit $env:GITHUB_SHA. Refusing to move the tag."
               exit 1
-            fi
+            }
 
-            case "$http_status" in
-              200)
-                echo "::error::$package_id $VERSION is already published on NuGet.org."
-                published_packages+=("$package_id")
-                ;;
-              404)
-                echo "$package_id $VERSION is available on NuGet.org."
-                ;;
-              *)
-                echo "::error::Unexpected NuGet.org response $http_status while checking $package_id $VERSION. Failing closed before build."
+            Write-Host "Release tag '$releaseTag' already points to the validated commit; accepting it."
+          }
+          else {
+            Write-Host "Release tag '$releaseTag' does not currently exist."
+          }
+
+          $versionLower = $env:VERSION.ToLowerInvariant()
+          foreach ($package in @(Get-FluentMapPackages)) {
+            $packageId = [string]$package.packageId
+            $packageIdLower = $packageId.ToLowerInvariant()
+            $packageUrl = "https://api.nuget.org/v3-flatcontainer/$packageIdLower/$versionLower/$packageIdLower.$versionLower.nupkg"
+            $httpStatus = (& curl `
+              --silent `
+              --show-error `
+              --location `
+              --proto '=https' `
+              --proto-redir '=https' `
+              --retry 3 `
+              --retry-delay 2 `
+              --retry-all-errors `
+              --connect-timeout 10 `
+              --max-time 30 `
+              --output /dev/null `
+              --write-out '%{http_code}' `
+              $packageUrl).Trim()
+
+            if ($LASTEXITCODE -ne 0) {
+              Write-Error "Unable to query NuGet.org for $packageId $env:VERSION. Failing closed before build."
+              exit 1
+            }
+
+            switch ($httpStatus) {
+              '200' {
+                Write-Host "NuGet.org already has $packageId $env:VERSION. Publication will validate the existing artifact before accepting it."
+              }
+              '404' {
+                Write-Host "NuGet.org does not currently have $packageId $env:VERSION. This does not prove the publisher is authorized to create the PackageId."
+              }
+              default {
+                Write-Error "Unexpected NuGet.org response HTTP $httpStatus while checking $packageId $env:VERSION. Failing closed before build."
                 exit 1
-                ;;
-            esac
-          done
+              }
+            }
+          }
 
-          if (( ${#published_packages[@]} > 0 )); then
-            echo "::error::Release version '$VERSION' is already published for: ${published_packages[*]}. Choose a new version."
-            exit 1
-          fi
-
-          echo "package_version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$release_tag" >> "$GITHUB_OUTPUT"
-          echo "is_prerelease=$is_prerelease" >> "$GITHUB_OUTPUT"
-          echo "Release version: $VERSION"
-          echo "Release tag: $release_tag"
-          echo "Preflight passed: tag is unused and the version is unpublished for all FluentMap NuGet packages."
+          "package_version=$env:VERSION" >> $env:GITHUB_OUTPUT
+          "release_tag=$releaseTag" >> $env:GITHUB_OUTPUT
+          "is_prerelease=$isPrerelease" >> $env:GITHUB_OUTPUT
+          "tag_exists=$tagExists" >> $env:GITHUB_OUTPUT
+          Write-Host "Release version: $env:VERSION"
+          Write-Host "Release tag: $releaseTag"
+          Write-Host 'Preflight passed: tag state is compatible and NuGet.org returned only expected package-version states.'
 
       - name: Show .NET info
         run: dotnet --info
@@ -226,14 +225,15 @@ jobs:
             Where-Object { $_.Extension -in @('.csproj', '.ps1') } |
             ForEach-Object {
               $content = Get-Content -LiteralPath $_.FullName -Raw
-              $updated = $content.Replace('3.0.0-rc.1', $env:PACKAGE_VERSION)
+              $updated = $content.Replace('3.0.1', $env:PACKAGE_VERSION)
               if ($updated -ne $content) {
                 [System.IO.File]::WriteAllText($_.FullName, $updated, [System.Text.UTF8Encoding]::new($false))
               }
             }
 
           ./eng/consumer-smoke/run-consumer-smoke.ps1 `
-            -PackageDirectory './artifacts/packages'
+            -PackageDirectory './artifacts/packages' `
+            -PackageVersion $env:PACKAGE_VERSION
 
       - name: Write dependency inventory
         shell: pwsh
@@ -247,14 +247,16 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
+          Import-Module './eng/PackageCatalog.psm1' -Force
           $artifactRoot = (Resolve-Path './artifacts').Path
           $packageFiles = @(
             Get-ChildItem './artifacts/packages' -File |
               Where-Object { $_.Extension -in @('.nupkg', '.snupkg') }
           )
+          $expectedPackageFileCount = @(Get-FluentMapPackages).Count + @(Get-FluentMapPackages -WithSymbols).Count
 
-          if ($packageFiles.Count -ne 8) {
-            throw "Expected 8 package artifacts for checksums, found $($packageFiles.Count)."
+          if ($packageFiles.Count -ne $expectedPackageFileCount) {
+            throw "Expected $expectedPackageFileCount package artifacts for checksums, found $($packageFiles.Count)."
           }
 
           $files = @(
@@ -301,7 +303,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --tags --force
+          git fetch --tags
           if git rev-parse -q --verify "refs/tags/$RELEASE_TAG" >/dev/null; then
             tag_sha="$(git rev-list -n 1 "$RELEASE_TAG")"
             if [[ "$tag_sha" != "$VALIDATED_SHA" ]]; then
@@ -328,6 +330,12 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          show-progress: false
+
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
@@ -359,24 +367,12 @@ jobs:
           PACKAGE_VERSION: ${{ needs.build-and-pack.outputs.package-version }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $packageIds = @(
-            'Dapper.FluentMap',
-            'Dapper.FluentMap.Dommel',
-            'Dapper.FluentMap.DependencyInjection',
-            'Dapper.FluentMap.Analyzers',
-            'Dapper.FluentMap.Generators'
-          )
-
-          foreach ($packageId in $packageIds) {
-            $package = "./artifacts/packages/$packageId.$env:PACKAGE_VERSION.nupkg"
-            dotnet nuget push $package `
-              --source 'https://api.nuget.org/v3/index.json' `
-              --api-key $env:NUGET_API_KEY
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "NuGet.org publication failed for $packageId. The version may already exist; refusing to suppress an unverified duplicate."
-            }
-          }
+          ./eng/publish-package-set.ps1 `
+            -PackageDirectory './artifacts/packages' `
+            -Version $env:PACKAGE_VERSION `
+            -Source 'https://api.nuget.org/v3/index.json' `
+            -ApiKey $env:NUGET_API_KEY `
+            -Registry NuGetOrg
 
   publish-github-packages:
     name: Publish to GitHub Packages
@@ -390,6 +386,12 @@ jobs:
       packages: write
 
     steps:
+      - name: Checkout release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+          show-progress: false
+
       - name: Setup .NET
         uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6
         with:
@@ -414,26 +416,17 @@ jobs:
           GITHUB_PACKAGE_SOURCE: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
           GITHUB_PACKAGE_TOKEN: ${{ github.token }}
           PACKAGE_VERSION: ${{ needs.build-and-pack.outputs.package-version }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $packageIds = @(
-            'Dapper.FluentMap',
-            'Dapper.FluentMap.Dommel',
-            'Dapper.FluentMap.DependencyInjection',
-            'Dapper.FluentMap.Analyzers',
-            'Dapper.FluentMap.Generators'
-          )
-
-          foreach ($packageId in $packageIds) {
-            $package = "./artifacts/packages/$packageId.$env:PACKAGE_VERSION.nupkg"
-            dotnet nuget push $package `
-              --source $env:GITHUB_PACKAGE_SOURCE `
-              --api-key $env:GITHUB_PACKAGE_TOKEN
-
-            if ($LASTEXITCODE -ne 0) {
-              throw "GitHub Packages publication failed for $packageId. The version may already exist; refusing to suppress an unverified duplicate."
-            }
-          }
+          ./eng/publish-package-set.ps1 `
+            -PackageDirectory './artifacts/packages' `
+            -Version $env:PACKAGE_VERSION `
+            -Source $env:GITHUB_PACKAGE_SOURCE `
+            -ApiKey $env:GITHUB_PACKAGE_TOKEN `
+            -Registry GitHubPackages `
+            -RepositoryOwner $env:REPOSITORY_OWNER `
+            -GitHubToken $env:GITHUB_PACKAGE_TOKEN
 
   github-release:
     name: Create GitHub Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,11 +150,11 @@ The repository currently publishes multiple NuGet packages:
 
 - `Dapper.FluentMap`
 - `Dapper.FluentMap.Dommel`
-- `Dapper.FluentMap.DependencyInjection`
-- `Dapper.FluentMap.Analyzers`
-- `Dapper.FluentMap.Generators`
+- `FluentMap.DependencyInjection`
+- `FluentMap.Analyzers`
+- `FluentMap.Generators`
 
-`Directory.Build.props` defines shared package metadata and `FluentMapPackageVersionPrefix` (currently `3.0.0`) with a local/dev suffix when no explicit version is supplied. `Directory.Build.targets` blocks unsafe historical package versions. Release behavior lives in the actual workflows under `.github/workflows/`; inspect them before changing or documenting release behavior.
+`eng/package-catalog.json` is the package identity catalog and separates project identity from NuGet `PackageId`. `Directory.Build.props` defines shared package metadata and `FluentMapPackageVersionPrefix` (currently `3.0.1`) with a local/dev suffix when no explicit version is supplied. `Directory.Build.targets` blocks unsafe historical package versions. Release behavior lives in the actual workflows under `.github/workflows/`; inspect them before changing or documenting release behavior.
 
 Package or release changes require compatibility, provenance, artifact-set, rollback/recovery, and SemVer review. Do not alter PackageIds, versioning, authors, license, URLs, README/icon packaging, Source Link/provenance, or NuGet metadata without explicit scope.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,536 +1,171 @@
 # AGENTS.md
 
-## Objetivo
+## Purpose
 
-Este repositório mantém o **Dapper.FluentMap**, uma biblioteca .NET que fornece uma API fluente para mapear propriedades de POCOs para colunas de banco de dados usadas pelo Dapper, mantendo os modelos livres de atributos de persistência.
+This repository maintains **Dapper.FluentMap**, a public multi-package .NET library that provides fluent, strongly typed mapping between POCO properties and database columns used by Dapper, keeping persistence attributes out of domain models.
 
-O trabalho realizado por agentes deve ser pequeno, correto, reproduzível e compatível com o comportamento público existente. Responda em português, salvo pedido explícito em outro idioma.
+Agent work must be small, correct, reproducible, and compatible with existing public behavior. Respond in Portuguese unless the user explicitly asks otherwise.
 
-A prioridade inicial é a evolução segura do projeto principal `Dapper.FluentMap`. O módulo `Dapper.FluentMap.Dommel` só deve ser alterado quando a tarefa o mencionar explicitamente ou quando uma mudança no core exigir uma adaptação comprovada.
+## Non-Negotiable Rules
 
-## Princípios do projeto
+| Area | Rule |
+| --- | --- |
+| Branching | The default development and release branch is `master`. Never modify `master` directly; create or use a task branch. |
+| Scope | Prefer the smallest cohesive change. Do not mix functional change, modernization, dependency updates, refactoring, and release work unless the task explicitly spans them. |
+| Public library | Preserve source, binary, and behavioral compatibility unless a breaking change is explicitly requested, justified, tested, documented, and versioned. |
+| Publishing | Do not publish packages, create tags, create GitHub Releases, or run release/recovery workflows unless explicitly requested. |
+| Secrets | Never commit secrets, tokens, API keys, certificates, or credential material. |
+| Identity | Project name, project path, assembly name, C# namespace, and NuGet `PackageId` are independent identities. Never rename one merely because another changes; determine explicitly which identity the task intends to change. |
+| Targets | Public packages currently preserve `netstandard2.0`. Do not change targets, multi-targeting, SDK, nullable, AOT, analyzers, test framework, or Central Package Management as incidental work. |
+| Dapper | Use public Dapper contracts only. Do not copy Dapper internals or assume unit metadata tests prove end-to-end Dapper materialization. |
 
-- Trate o repositório como uma **biblioteca pública**, não como uma aplicação interna.
-- Preserve compatibilidade de código-fonte, binária e comportamental sempre que possível.
-- Não introduza breaking changes sem solicitação explícita, justificativa técnica, testes e estratégia de versionamento.
-- Prefira alterações pequenas, coesas, revisáveis e cobertas por testes.
-- Não transforme o FluentMap em ORM, query builder, gerador de SQL ou camada de CRUD.
-- Mantenha o diferencial principal: mapeamento fluente, fortemente tipado e sem atributos no modelo.
-- Não implemente recomendações apenas por serem boas práticas genéricas. Exija benefício observável, correção, redução de risco ou requisito claro.
-- Não misture modernização, refatoração estrutural, atualização de dependências e mudança funcional no mesmo trabalho sem necessidade explícita.
-- Não altere testes apenas para fazê-los passar.
-- Não publique pacotes, tags, releases ou versões sem solicitação explícita.
+## Repository Map
 
-## Fontes de verdade
+| Path | Role |
+| --- | --- |
+| `src/Dapper.FluentMap/` | Core package and default production scope. |
+| `src/Dapper.FluentMap.Dommel/` | Optional Dommel integration; change only when requested or demonstrably required by a core contract change. |
+| `src/Dapper.FluentMap.DependencyInjection/` | Optional DI integration. |
+| `src/Dapper.FluentMap.Analyzers/` | Roslyn analyzer package. |
+| `src/Dapper.FluentMap.Generators/` | Source generator package. |
+| `test/**` | Unit, integration, provider, analyzer/generator, DI, generated-registration, and AOT smoke tests. |
+| `benchmarks/**` | Benchmarks; not part of ordinary validation unless the task concerns performance. |
+| `eng/**` | Validation, release, rollback, Sonar, and consumer-smoke helper scripts. |
+| `.github/workflows/**` | CI, release, release recovery, and Sonar automation. |
 
-Consulte apenas os arquivos relevantes para a tarefa atual, priorizando:
+Prefer `Dapper.FluentMap.slnx` for current SDK workflows; `Dapper.FluentMap.sln` remains a compatibility fallback.
+
+## Sources Of Truth
+
+Read only what the task needs, in this order:
 
 1. `AGENTS.md`
-2. `README.md`
-3. `Dapper.FluentMap.sln`
-4. `src/Dapper.FluentMap/Dapper.FluentMap.csproj`
-5. `src/Dapper.FluentMap/`
-6. `test/Dapper.FluentMap.Tests/Dapper.FluentMap.Tests.csproj`
-7. `test/Dapper.FluentMap.Tests/`
-8. `src/Dapper.FluentMap.Dommel/` e seus testes, somente quando o escopo incluir Dommel
-9. `NuGet.Config`
-10. `LICENSE`
-11. `.editorconfig`, `global.json`, `Directory.Build.props`, `Directory.Packages.props` e workflows, quando existirem e forem relevantes
-
-Não carregue indiscriminadamente todo o repositório. Localize primeiro o contrato, tipo, teste, issue ou comportamento diretamente relacionado à tarefa.
-
-## Estrutura do repositório
-
-- `src/Dapper.FluentMap/`: biblioteca principal e escopo padrão das mudanças.
-- `test/Dapper.FluentMap.Tests/`: testes da biblioteca principal.
-- `src/Dapper.FluentMap.Dommel/`: integração opcional com Dommel.
-- `test/Dapper.FluentMap.Dommel.Tests/`: testes da integração Dommel.
-- `Dapper.FluentMap.sln`: solution agregadora.
-
-Mudanças no core não devem incluir Dommel automaticamente. Quando uma alteração pública no core puder afetar Dommel, avalie o impacto, mas não amplie o escopo sem evidência ou pedido explícito.
-
-## Regras obrigatórias
-
-- Faça a menor mudança possível para resolver o problema.
-- Preserve a API pública existente, salvo quando a tarefa pedir explicitamente uma mudança de contrato.
-- Antes de alterar comportamento público, identifique usos, testes e compatibilidade esperada.
-- Para bugs, crie primeiro um teste de regressão que reproduza a falha quando isso for viável.
-- Para refatorações, use testes de caracterização quando o comportamento não estiver suficientemente protegido.
-- Não torne membros públicos apenas para facilitar testes.
-- Não silencie warnings, exceções ou testes sem justificativa técnica.
-- Não use `Skip`, remova asserts ou reduza verificações para obter uma suíte verde.
-- Não introduza `Task.Delay`, sleeps, dependência de horário, rede externa ou ordem entre testes.
-- Não adicione dependências sem necessidade clara.
-- Não adote Central Package Management, novo framework de testes, source generator, analyzer, NativeAOT ou nullable em uma tarefa não relacionada.
-- Não altere `PackageId`, versão, autores, licença, URLs do pacote ou metadados de publicação sem solicitação explícita.
-- Não faça publish para NuGet.
-- Não introduza segredos, tokens, chaves ou credenciais.
-- Não faça alterações diretamente na branch `master`.
-- Não abra pull request, publique branch, crie tag ou release sem solicitação explícita.
-
-## Escopo funcional do core
-
-O projeto principal deve permanecer focado em:
-
-- registro de mapas de entidades;
-- mapeamento entre propriedades e nomes de colunas;
-- convenções de nomes;
-- resolução de membros pelo Dapper;
-- composição previsível entre mapeamentos explícitos, convenções e comportamento padrão;
-- validação e diagnóstico de configuração;
-- compatibilidade com tipos, construtores e modelos suportados pelo contrato definido.
-
-Não adicionar ao core sem decisão explícita:
-
-- mapeamento de tabela;
-- chave primária, identidade ou geração de identificador;
-- CRUD;
-- geração de SQL;
-- tracking de entidades;
-- unit of work;
-- migrations;
-- abstração de conexão;
-- query builder;
-- recursos específicos de Dommel;
-- atributos de persistência como abordagem principal.
-
-Quando houver composição entre estratégias de resolução, preserve uma precedência explícita e testável. A direção preferencial é:
-
-1. mapeamento explícito;
-2. convenção configurada;
-3. comportamento padrão do Dapper.
-
-Não assuma que esse comportamento já existe em todos os caminhos atuais. Ao implementá-lo ou alterá-lo, proteja-o com testes.
-
-## Compatibilidade pública e SemVer
-
-Considere compatíveis ou incompatíveis, conforme o caso:
-
-- assinaturas públicas;
-- nomes de tipos e namespaces;
-- construtores públicos;
-- interfaces públicas;
-- comportamento de `FluentMapper.Initialize`;
-- comportamento de `EntityMap`, `PropertyMap`, convenções e type maps;
-- tipos de exceção observáveis;
-- mensagens de erro usadas apenas para diagnóstico, sem prometer texto exato salvo teste ou documentação explícita;
-- targets suportados;
-- dependências transitivas;
-- comportamento de resolução case-sensitive e case-insensitive.
-
-Antes de realizar breaking change:
-
-1. descreva o contrato atual;
-2. explique por que não é possível preservar compatibilidade;
-3. identifique impacto para consumidores;
-4. crie ou atualize testes;
-5. proponha versão major;
-6. atualize documentação;
-7. não implemente sem pedido explícito.
-
-Correções de bugs podem alterar comportamento incorreto, mas devem ter teste de regressão e explicação clara.
-
-## Frameworks e arquivos de projeto
-
-- O projeto principal deve preservar `netstandard2.0` enquanto não houver decisão explícita de compatibilidade diferente.
-- Projetos de teste podem usar runtimes modernos, como .NET 8 e .NET 10, sem obrigar a biblioteca publicada a abandonar `netstandard2.0`.
-- Multi-targeting deve existir apenas quando houver finalidade de compatibilidade e validação clara.
-- Não use `TargetFrameworks` quando houver somente um target.
-- Atualizações de SDK, Test SDK, xUnit, Dapper ou Dommel devem ser separadas de correções funcionais sempre que possível.
-- Não migre para xUnit v3 junto com a primeira migração de runtime, salvo pedido explícito.
-- Não introduza nullable e corrija centenas de warnings junto com uma tarefa não relacionada.
-- Não adote Central Package Management sem avaliar custo, benefício e impacto no repositório pequeno.
-- Respeite o formato e as convenções atuais dos arquivos `.csproj`, salvo modernização intencional.
-
-## Reflexão e expressões
-
-Código que interpreta expressões deve:
-
-- trabalhar diretamente com os membros representados pela expressão quando possível;
-- aceitar conversões legítimas produzidas por `Expression<Func<TEntity, object>>`;
-- validar se o membro final é uma propriedade suportada;
-- rejeitar expressões inválidas com exceção específica e mensagem útil;
-- não selecionar membros apenas por nome usando o primeiro resultado de reflection;
-- não confundir propriedades com métodos, campos ou membros homônimos;
-- preservar suporte a propriedades herdadas quando compatível;
-- ter testes para propriedades com nomes que colidem com membros de tipos como `string`, `DateTime` e `TimeSpan`.
-
-Mapeamento aninhado e Value Objects não devem ser tratados como simples correção de reflection. Antes de declarar suporte, valide materialização completa, criação de objetos intermediários, construtores, nulabilidade, cache e integração real com o Dapper.
-
-## Estado global, registro e cache
-
-O projeto possui configuração e integração global com o Dapper. Qualquer alteração nessa área deve considerar:
-
-- thread safety;
-- inicialização repetida;
-- isolamento entre testes;
-- invalidação de cache;
-- concorrência entre registros;
-- múltiplas entidades;
-- múltiplos processos de resolução;
-- efeitos de `SqlMapper.SetTypeMap`;
-- compatibilidade com consumidores que inicializam a biblioteca uma vez no startup.
-
-Regras:
-
-- Não introduza novo estado global mutável sem justificativa.
-- Prefira descritores imutáveis depois da configuração.
-- Use chaves de cache estruturadas; evite concatenação de strings sujeita a colisões.
-- Inclua no cache todas as opções que alteram o resultado, como tipo, nome de coluna e comparação.
-- Defina e teste quando o cache deve ser invalidado.
-- Não dependa de ordem de execução dos testes.
-- Quando necessário, forneça mecanismo interno ou público bem definido para reset controlado em testes, sem comprometer consumidores.
-- Ao refatorar configuração estática, preserve uma fachada compatível antes de remover contratos antigos.
-
-## Convenções e mapeamentos explícitos
-
-Ao alterar convenções:
+2. Relevant `.agents/skills/*/SKILL.md`
+3. User request, issue, PR, or diff
+4. `README.md`, `COMPATIBILITY.md`, `MIGRATION.md`, `CHANGELOG.md` when behavior or compatibility is involved
+5. `Dapper.FluentMap.slnx` / `Dapper.FluentMap.sln`
+6. Relevant `.csproj`, `Directory.Build.props`, `Directory.Build.targets`, `global.json`, `NuGet.Config`
+7. Relevant source and test files
+8. Relevant workflows and `eng` scripts when CI, packaging, or release is involved
 
-- preserve filtros, transformações, prefixos e configuração por entidade;
-- detecte ambiguidades de forma determinística;
-- não permita que uma convenção sobrescreva silenciosamente um mapeamento explícito;
-- não compartilhe estado mutável acidentalmente entre tipos;
-- teste mais de uma entidade usando a mesma convenção;
-- teste configuração case-sensitive e case-insensitive;
-- evite scanning amplo sem filtros quando uma alternativa explícita for viável.
+Do not load the whole repository by default. Search first with `rg` / `rg --files`, then open the narrow files that define the contract, implementation, tests, or automation being changed.
 
-Ao alterar mapeamentos explícitos:
+## Skill Routing
 
-- identifique propriedades por membro ou caminho completo, não apenas pelo nome terminal quando houver suporte a caminhos;
-- detecte duplicidades reais;
-- diferencie `Rank.Level` de `Seniority.Level` em qualquer modelo futuro de caminho;
-- não declare suporte a propriedades aninhadas antes de a materialização estar implementada de ponta a ponta.
+Read `AGENTS.md` first. Load only the skills relevant to the current task; do not load every skill by default. Multiple skills may be combined when the task genuinely spans multiple concerns. Repository-specific rules in this file take precedence over generic guidance in a skill. Skills must inspect the current repository rather than assuming their source-template baseline still applies.
 
-## Dapper
+| Task | Primary skill |
+| --- | --- |
+| Implement a well-defined issue | `dotnet-issue-implementation` |
+| Production/library/project/PackageId change | `dotnet-library-change` |
+| Behavior-preserving refactoring | `dotnet-refactoring-engineer` |
+| Pull request/diff review | `dotnet-pr-review` |
+| CI, packaging, NuGet, versioning, release or recovery | `ci-release-governance` |
 
-- Use apenas contratos públicos do Dapper.
-- Não copie implementação interna do Dapper sem justificativa e avaliação de licença.
-- Atualize Dapper em tarefa separada quando possível.
-- Ao atualizar Dapper, revise mudanças em `ITypeMap`, `IMemberMap`, `DefaultTypeMap`, constructor mapping, type handlers e comportamento de cache.
-- Teste o comportamento com uma consulta real quando a mudança depender da materialização do Dapper.
-- Não reimplemente `TypeHandler` sem necessidade; prefira integrar-se ao mecanismo do Dapper.
-- Não suponha que uma correção unitária de metadata garante materialização correta.
+## FluentMap Behavior Rules
 
-## Testes
+- Keep the core focused on mapping registration, property/column resolution, conventions, naming policies, Dapper member resolution, diagnostics, and predictable composition.
+- Do not turn FluentMap into an ORM, CRUD layer, SQL generator, query builder, connection abstraction, unit of work, migration tool, or entity tracker.
+- Default mapping precedence should remain explicit mapping, then configured convention, then Dapper default behavior. If a path does not currently prove that order, test it before changing it.
+- `Ignore()` and persistence metadata must preserve documented semantics across core and Dommel consumers.
+- Nested mappings and value objects require end-to-end materialization support. Do not claim support based only on expression parsing or reflection metadata.
 
-### Estratégia
+## Compatibility And SemVer
 
-Use a menor camada capaz de proteger o risco real:
+Treat these as compatibility-sensitive: public signatures, type names, namespaces, constructors, interfaces, `FluentMapper.Initialize`, `EntityMap`, `PropertyMap`, conventions, type maps, observable exception types, target frameworks, dependency ranges, package metadata, and case-sensitive/case-insensitive resolution behavior.
 
-- teste unitário para expression parsing, metadata, duplicidade, convenções, cache e validação;
-- teste de integração simples com Dapper para materialização, construtores, type maps e consultas;
-- banco em memória ou efêmero quando suficiente;
-- nenhuma dependência de serviço externo para testes padrão.
+Before a breaking change:
 
-### Regras
+1. Describe the current contract and consumer impact.
+2. Explain why compatibility cannot be preserved.
+3. Add or update tests and documentation.
+4. Propose the required SemVer impact.
+5. Do not implement unless the user explicitly requested that direction.
 
-- Teste comportamento observável, não detalhes privados.
-- Use Arrange, Act e Assert de forma clara.
-- Dê nomes que descrevam cenário e resultado esperado.
-- Cubra sucesso, falha e ambiguidade relevantes.
-- Toda correção de bug deve ter teste de regressão.
-- Não aceite teste sem assert significativo.
-- Evite `NotNull` como única validação de objeto complexo.
-- Evite over-mocking do próprio mecanismo que está sendo testado.
-- Não replique a implementação no assert.
-- Não compartilhe estado mutável entre testes.
-- Restaure type maps e configuração global quando o teste os alterar.
-- Se a suíte desabilitar paralelismo por causa do estado global, não reabilite sem eliminar ou isolar a causa.
-- Não use cobertura como substituto de qualidade.
+Bug fixes may correct incorrect behavior, but they need regression tests and a clear explanation of changed observable behavior.
 
-## Empacotamento NuGet
+## Dapper, State, And Cache
 
-Quando uma tarefa alterar embalagem, metadata ou compatibilidade do pacote:
+This repository has global configuration paths through FluentMap, Dapper `SqlMapper.SetTypeMap`, and Dommel. Changes in that area must consider thread safety, repeated initialization, test isolation, cache invalidation, concurrent registration, multiple entities/profiles, and startup-style initialization used by consumers.
 
-1. execute build em `Release`;
-2. execute `dotnet pack`;
-3. inspecione o `.nupkg`;
-4. verifique assemblies, XML documentation, dependências e targets;
-5. confirme que arquivos de teste ou artefatos indevidos não foram incluídos;
-6. revise impacto de SemVer;
-7. não publique.
+- Do not add mutable global state without a specific reason.
+- Prefer immutable descriptors after configuration is complete.
+- Use structured cache keys that include every option affecting resolution, such as type, column name, profile, comparison, and naming policy.
+- Define and test cache invalidation when behavior can change after registration.
+- Restore global type maps/configuration in tests that mutate them.
 
-Preserve licença e atribuição do projeto original. Não remova créditos históricos sem decisão explícita.
+## Expressions And Reflection
 
-## Documentação
+Expression parsing must work with the actual member represented by the expression, including legitimate conversions from `Expression<Func<TEntity, object>>`. Validate that the final member is a supported property, reject invalid expressions with useful diagnostics, preserve compatible inherited-property behavior, and avoid resolving by terminal name alone when homonyms or nested paths can collide.
 
-Atualize documentação quando houver:
+## Tests
 
-- nova API pública;
-- alteração de inicialização;
-- nova convenção;
-- alteração de comportamento;
-- mudança de compatibilidade;
-- novo target suportado;
-- mudança de pacote ou dependência relevante;
-- depreciação;
-- breaking change.
+Use the smallest test layer that protects the risk:
 
-Regras:
+| Risk | Preferred validation |
+| --- | --- |
+| Expression parsing, metadata, duplicates, conventions, cache, validation | Unit tests. |
+| Dapper materialization, constructors, type maps, query helpers | Integration tests with an in-memory/ephemeral provider when possible. |
+| Provider-specific behavior | Provider compatibility tests; do not require external services for the default suite. |
+| Analyzer/generator behavior | Roslyn analyzer/generator tests. |
+| Packaging and consumer experience | Pack validation plus `eng/consumer-smoke/run-consumer-smoke.ps1` when relevant. |
 
-- `README.md` deve continuar sendo a porta de entrada.
-- Exemplos devem compilar ou refletir a API real.
-- Não documente recurso ainda não implementado.
-- Preserve documentação XML em APIs públicas.
-- Para decisões arquiteturais importantes, registre uma issue de design ou documento de decisão, sem criar burocracia para correções pequenas.
-- Issues arquivadas do projeto original são evidência de demanda ou defeito histórico, não requisitos automáticos.
+Do not weaken tests to get a green suite: no unjustified `Skip`, removed asserts, sleeps, time/network coupling, order dependence, or over-mocking of FluentMap itself.
 
-## Skills
+## Validation Commands
 
-Antes de executar tarefa especializada, verifique `.agents/skills/` e selecione somente as skills relacionadas ao pedido. Ter todas as skills disponíveis não significa carregar todas em toda tarefa.
+Start with the closest validation. For documentation-only or agent-governance changes, prefer file existence, content searches, diff review, and targeted lint/format checks if available; do not run expensive build/test suites unless needed.
 
-As regras deste `AGENTS.md` prevalecem quando uma skill genérica conflitar com o contexto do FluentMap.
-
-### Governança e processo
-
-#### `repository-governance-sdd`
-
-Use para:
-
-- criar ou revisar skills;
-- alterar `AGENTS.md`;
-- estruturar prompts;
-- organizar documentação de processo;
-- decidir entre issue, documentação e decisão arquitetural.
-
-Não use para implementar código de produção ou testes.
-
-### Refatoração de código
-
-#### `dotnet-refactoring-engineer`
-
-Use para:
-
-- correções e refatorações em C#;
-- melhoria de legibilidade, coesão, testabilidade e performance;
-- redução de estado global;
-- revisão de design;
-- preservação de comportamento;
-- code review.
-
-Combine com as regras de compatibilidade pública deste arquivo.
-
-### MSBuild e projetos
-
-#### `msbuild-modernization`
-
-Use para:
-
-- modernizar `.csproj`;
-- atualizar `TargetFramework`;
-- configurar multi-targeting;
-- revisar propriedades de build;
-- modernizar SDK e estrutura MSBuild.
-
-#### `msbuild-antipatterns`
-
-Use para:
-
-- revisar duplicação e condições desnecessárias;
-- detectar propriedades redundantes;
-- evitar targets frágeis;
-- revisar uso incorreto de itens e referências.
-
-Use após ou durante mudanças em arquivos de projeto, sem ampliar escopo para modernização não solicitada.
-
-### Execução e diagnóstico de testes
-
-#### `run-tests`
-
-Use para:
-
-- descobrir e executar os testes;
-- aplicar filtros;
-- executar por projeto ou target;
-- diagnosticar falhas de descoberta e execução.
-
-Esta é a skill padrão para validação da suíte.
-
-### Qualidade dos testes
-
-Use estas skills somente depois de a suíte compilar e, quando aplicável, possuir uma baseline conhecida.
-
-#### `test-anti-patterns`
-
-Use para auditar:
-
-- ausência de asserts;
-- asserts fracos;
-- sleeps;
-- flakiness;
-- dependência de ordem;
-- over-mocking;
-- acoplamento a implementação;
-- cobertura artificial.
-
-#### `assertion-quality`
-
-Use para revisar força, precisão e relevância dos asserts.
-
-#### `test-gap-analysis`
-
-Use para identificar cenários importantes sem cobertura, especialmente contratos públicos, falhas, ambiguidades, concorrência e regressões históricas.
-
-#### `coverage-analysis`
-
-Use para analisar cobertura em conjunto com risco e comportamento. Não persiga percentual isolado.
-
-#### `detect-static-dependencies`
-
-Use ao investigar:
-
-- estado global;
-- membros estáticos;
-- caches estáticos;
-- isolamento entre testes;
-- dependência de ordem;
-- flakiness relacionada a `FluentMapper` e `SqlMapper`.
-
-### Migrações específicas
-
-Estas skills devem ser usadas em tarefas próprias e isoladas.
-
-#### `migrate-xunit-to-xunit-v3`
-
-Use apenas quando a tarefa pedir explicitamente migração para xUnit v3. Não combine por padrão com migração inicial de runtime ou atualização geral de pacotes.
-
-#### `migrate-nullable-references`
-
-Use apenas em trabalho dedicado para habilitar nullable, classificar warnings e corrigir contratos de nulabilidade. Preserve compatibilidade pública e evite mudanças indiscriminadas em assinaturas.
-
-#### `dotnet-aot-compat`
-
-Use para avaliação ou implementação dedicada de:
-
-- trimming;
-- NativeAOT;
-- reflection;
-- assembly scanning;
-- `Activator.CreateInstance`;
-- source generation;
-- anotações de preservação.
-
-Não declare compatibilidade AOT apenas porque o projeto compila. Exija validação real.
-
-## Roteamento recomendado de skills
-
-- Alterar `AGENTS.md`, skills ou processo:
-  - `repository-governance-sdd`
-- Refatorar ou corrigir código C#:
-  - `dotnet-refactoring-engineer`
-  - `run-tests`
-- Alterar `.csproj`, target ou SDK:
-  - `msbuild-modernization`
-  - `msbuild-antipatterns`
-  - `run-tests`
-- Corrigir bug relacionado a estado estático ou cache:
-  - `dotnet-refactoring-engineer`
-  - `detect-static-dependencies`
-  - `run-tests`
-- Auditar suíte já funcional:
-  - `test-anti-patterns`
-  - `assertion-quality`
-  - `test-gap-analysis`
-  - `coverage-analysis`, quando houver dados de cobertura
-- Migrar xUnit:
-  - `migrate-xunit-to-xunit-v3`
-  - `run-tests`
-- Habilitar nullable:
-  - `migrate-nullable-references`
-  - `run-tests`
-- Avaliar AOT/trimming:
-  - `dotnet-aot-compat`
-  - `run-tests`
-
-Não combine skills sem relação direta. Uma skill complementar não pode ampliar o escopo definido pelo pedido.
-
-## Processo de implementação
-
-1. Identifique o escopo: core, testes, Dommel, build, documentação ou empacotamento.
-2. Leia os arquivos diretamente relacionados.
-3. Selecione as skills necessárias.
-4. Descreva o comportamento atual e o risco.
-5. Localize testes existentes.
-6. Crie teste de regressão ou caracterização quando necessário.
-7. Faça a menor alteração coesa.
-8. Execute validação localizada.
-9. Execute build e testes mais amplos quando o impacto justificar.
-10. Execute pack quando houver impacto de pacote.
-11. Revise o diff para remover churn, renomeações ou formatação fora do escopo.
-12. Registre validações executadas, limitações e riscos restantes.
-13. Faça commit semântico apenas quando a alteração estiver coerente e validada.
-
-## Validação
-
-Comece pela validação mais próxima da mudança.
-
-### Biblioteca principal
+Core baseline:
 
 ```bash
-dotnet restore ./Dapper.FluentMap.sln
+dotnet restore ./Dapper.FluentMap.slnx
 dotnet build ./src/Dapper.FluentMap/Dapper.FluentMap.csproj --configuration Release --no-restore
 dotnet test ./test/Dapper.FluentMap.Tests/Dapper.FluentMap.Tests.csproj --configuration Release
 ```
 
-### Solution completa
-
-Use quando a alteração for transversal ou afetar contratos usados por Dommel:
+Full solution baseline:
 
 ```bash
-dotnet restore ./Dapper.FluentMap.sln
-dotnet build ./Dapper.FluentMap.sln --configuration Release --no-restore
-dotnet test ./Dapper.FluentMap.sln --configuration Release --no-build
+dotnet restore ./Dapper.FluentMap.slnx
+dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
+dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build
 ```
 
-### Pacote
-
-Use quando a alteração afetar o pacote principal:
+Packaging baseline when package output, metadata, compatibility, or release is affected:
 
 ```bash
-dotnet pack ./src/Dapper.FluentMap/Dapper.FluentMap.csproj \
-  --configuration Release \
-  --no-build \
-  --output ./artifacts/packages
+dotnet restore ./Dapper.FluentMap.slnx
+dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
+dotnet pack ./Dapper.FluentMap.slnx --configuration Release --no-build --output ./artifacts/packages
+./eng/validate-package-metadata.ps1 -PackageDirectory './artifacts/packages'
+./eng/validate-release-artifacts.ps1 -PackageDirectory './artifacts/packages' -Version <version> -ManifestPath './artifacts/release-metadata/artifact-manifest.json' -Repository <owner/repo> -RepositoryUrl <url> -Commit <sha> -Branch <ref>
 ```
 
-Quando houver multi-targeting, valide cada target relevante. Quando a máquina não possuir o runtime necessário, não instale silenciosamente versões adicionais e não altere targets apenas para contornar o ambiente; registre a limitação ou use a matriz de CI quando disponível.
+If the local SDK/runtime cannot run a required target, do not change project targets to work around the machine. Report the command, failure, and what remains unvalidated.
 
-Se a baseline original estiver quebrada antes da mudança, registre:
+## Packaging And Release
 
-- comando executado;
-- falha observada;
-- se a falha é anterior à alteração;
-- o que foi ou não validado.
+The repository currently publishes multiple NuGet packages:
 
-## Git e commits
+- `Dapper.FluentMap`
+- `Dapper.FluentMap.Dommel`
+- `Dapper.FluentMap.DependencyInjection`
+- `Dapper.FluentMap.Analyzers`
+- `Dapper.FluentMap.Generators`
 
-- A branch padrão é `master`; nunca aplique alterações diretamente nela.
-- Crie ou use branch de trabalho relacionada ao objetivo.
-- Use Conventional Commits:
-  - `fix:` para correção funcional;
-  - `feat:` para nova capacidade;
-  - `refactor:` para mudança estrutural sem mudança observável;
-  - `test:` para testes;
-  - `docs:` para documentação;
-  - `chore:` para manutenção;
-  - `ci:` para automação.
-- Não misture assuntos independentes no mesmo commit.
-- Revise o diff antes de commitar.
-- Não faça commit com falha de build ou teste sem registrar claramente o motivo.
-- Não faça push, abra pull request, crie tag ou release sem pedido explícito.
-- Não reescreva histórico compartilhado.
-- Não use `--force` sem autorização explícita.
+`Directory.Build.props` defines shared package metadata and `FluentMapPackageVersionPrefix` (currently `3.0.0`) with a local/dev suffix when no explicit version is supplied. `Directory.Build.targets` blocks unsafe historical package versions. Release behavior lives in the actual workflows under `.github/workflows/`; inspect them before changing or documenting release behavior.
 
-## Formato da resposta final
+Package or release changes require compatibility, provenance, artifact-set, rollback/recovery, and SemVer review. Do not alter PackageIds, versioning, authors, license, URLs, README/icon packaging, Source Link/provenance, or NuGet metadata without explicit scope.
 
-Ao concluir uma tarefa, informe:
+## Documentation
 
-1. objetivo atendido;
-2. arquivos alterados;
-3. comportamento preservado ou alterado;
-4. testes e comandos executados;
-5. resultado do build, testes e pack;
-6. riscos ou limitações restantes;
-7. commit criado, quando aplicável.
+Update docs when public API, initialization, behavior, compatibility, supported targets, package/dependency behavior, deprecations, or release flow changes. `README.md` is the entry point; examples must compile or accurately reflect the real API. Do not document unimplemented features.
 
-Não declare sucesso quando uma validação necessária não tiver sido executada. Explique objetivamente o que ficou sem validar e por quê.
+## Git
+
+Use Conventional Commits (`fix:`, `feat:`, `refactor:`, `test:`, `docs:`, `chore:`, `ci:`). Review the complete diff before committing. Do not push, open PRs, create tags, create releases, or publish packages unless the user explicitly requested it.
+
+## Final Report
+
+When finishing a task, report the objective, files changed, behavior preserved or changed, validations performed and results, build/test/pack status when applicable, remaining risks or limitations, and commit SHA when a commit was created.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Agent work must be small, correct, reproducible, and compatible with existing pu
 | Publishing | Do not publish packages, create tags, create GitHub Releases, or run release/recovery workflows unless explicitly requested. |
 | Secrets | Never commit secrets, tokens, API keys, certificates, or credential material. |
 | Identity | Project name, project path, assembly name, C# namespace, and NuGet `PackageId` are independent identities. Never rename one merely because another changes; determine explicitly which identity the task intends to change. |
-| Targets | Public packages currently preserve `netstandard2.0`. Do not change targets, multi-targeting, SDK, nullable, AOT, analyzers, test framework, or Central Package Management as incidental work. |
+| Targets | Public packages currently preserve `netstandard2.0`. Do not change targets, multi-targeting, SDK, nullable, AOT, analyzers, test framework, or the repository's dependency-versioning model as incidental work. |
 | Dapper | Use public Dapper contracts only. Do not copy Dapper internals or assume unit metadata tests prove end-to-end Dapper materialization. |
 
 ## Repository Map
@@ -29,9 +29,10 @@ Agent work must be small, correct, reproducible, and compatible with existing pu
 | `src/Dapper.FluentMap.Analyzers/` | Roslyn analyzer package. |
 | `src/Dapper.FluentMap.Generators/` | Source generator package. |
 | `test/**` | Unit, integration, provider, analyzer/generator, DI, generated-registration, and AOT smoke tests. |
-| `benchmarks/**` | Benchmarks; not part of ordinary validation unless the task concerns performance. |
-| `eng/**` | Validation, release, rollback, Sonar, and consumer-smoke helper scripts. |
+| `benchmarks/**` | BenchmarkDotNet benchmarks; not part of ordinary validation unless the task concerns performance. |
+| `eng/**` | Validation, release, rollback, Sonar, package-catalog, and consumer-smoke helper scripts. |
 | `.github/workflows/**` | CI, release, release recovery, and Sonar automation. |
+| `.agents/skills/**` | Repository-local agent skills; load only those relevant to the current task. |
 
 Prefer `Dapper.FluentMap.slnx` for current SDK workflows; `Dapper.FluentMap.sln` remains a compatibility fallback.
 
@@ -60,7 +61,21 @@ Read `AGENTS.md` first. Load only the skills relevant to the current task; do no
 | Production/library/project/PackageId change | `dotnet-library-change` |
 | Behavior-preserving refactoring | `dotnet-refactoring-engineer` |
 | Pull request/diff review | `dotnet-pr-review` |
-| CI, packaging, NuGet, versioning, release or recovery | `ci-release-governance` |
+| CI, packaging, NuGet, versioning, release or recovery semantics | `ci-release-governance` |
+| GitHub Actions YAML authoring/structural validation | `authoring-github-workflows` |
+| NuGet.org OIDC/trusted-publishing review or diagnosis | `nuget-trusted-publishing` |
+| Find caller-visible behaviors existing tests would miss | `test-gap-analysis` |
+| BenchmarkDotNet/performance comparison | `microbenchmarking` |
+| `Directory.Build.*` / MSBuild organization | `directory-build-organization` |
+| Diagnose unclear MSBuild failures from `.binlog` | `binlog-failure-analysis` |
+
+Pair skills when concerns overlap. Examples:
+
+- release workflow change: `ci-release-governance` + `authoring-github-workflows`; add `nuget-trusted-publishing` when NuGet.org OIDC is involved;
+- performance-sensitive library change: `dotnet-library-change` + `microbenchmarking` when measurement is required;
+- implementation with uncertain test protection: implementation/refactoring skill + `test-gap-analysis`;
+- build-property refactor: `directory-build-organization` + `dotnet-library-change` when package/public compatibility can be affected;
+- opaque MSBuild failure: `binlog-failure-analysis`, then the relevant implementation/build skill once the cause is established.
 
 ## FluentMap Behavior Rules
 
@@ -92,7 +107,7 @@ This repository has global configuration paths through FluentMap, Dapper `SqlMap
 - Prefer immutable descriptors after configuration is complete.
 - Use structured cache keys that include every option affecting resolution, such as type, column name, profile, comparison, and naming policy.
 - Define and test cache invalidation when behavior can change after registration.
-- Restore global type maps/configuration in tests that mutate them.
+- Restore global type maps/configuration in tests and benchmarks that mutate them.
 
 ## Expressions And Reflection
 
@@ -109,12 +124,13 @@ Use the smallest test layer that protects the risk:
 | Provider-specific behavior | Provider compatibility tests; do not require external services for the default suite. |
 | Analyzer/generator behavior | Roslyn analyzer/generator tests. |
 | Packaging and consumer experience | Pack validation plus `eng/consumer-smoke/run-consumer-smoke.ps1` when relevant. |
+| Performance regression/optimization | Existing BenchmarkDotNet project with a controlled baseline; do not infer performance from unit-test duration. |
 
 Do not weaken tests to get a green suite: no unjustified `Skip`, removed asserts, sleeps, time/network coupling, order dependence, or over-mocking of FluentMap itself.
 
 ## Validation Commands
 
-Start with the closest validation. For documentation-only or agent-governance changes, prefer file existence, content searches, diff review, and targeted lint/format checks if available; do not run expensive build/test suites unless needed.
+Start with the closest validation. For documentation-only or agent-governance changes, prefer file existence, content searches, diff review, and targeted lint checks; do not run expensive build/test suites unless needed.
 
 Core baseline:
 
@@ -132,6 +148,14 @@ dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
 dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build
 ```
 
+Workflow validation when `.github/workflows/**` changes:
+
+```bash
+python -m check_jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml
+```
+
+Use `authoring-github-workflows` for additional `actionlint` validation when structural/expression risk warrants it.
+
 Packaging baseline when package output, metadata, compatibility, or release is affected:
 
 ```bash
@@ -140,6 +164,13 @@ dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
 dotnet pack ./Dapper.FluentMap.slnx --configuration Release --no-build --output ./artifacts/packages
 ./eng/validate-package-metadata.ps1 -PackageDirectory './artifacts/packages'
 ./eng/validate-release-artifacts.ps1 -PackageDirectory './artifacts/packages' -Version <version> -ManifestPath './artifacts/release-metadata/artifact-manifest.json' -Repository <owner/repo> -RepositoryUrl <url> -Commit <sha> -Branch <ref>
+```
+
+Benchmark validation when performance is in scope:
+
+```bash
+dotnet build ./benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj --configuration Release
+dotnet run --project ./benchmarks/Dapper.FluentMap.Benchmarks/Dapper.FluentMap.Benchmarks.csproj --configuration Release --no-build -- --filter "*RelevantBenchmark*" --job Dry
 ```
 
 If the local SDK/runtime cannot run a required target, do not change project targets to work around the machine. Report the command, failure, and what remains unvalidated.
@@ -154,7 +185,9 @@ The repository currently publishes multiple NuGet packages:
 - `FluentMap.Analyzers`
 - `FluentMap.Generators`
 
-`eng/package-catalog.json` is the package identity catalog and separates project identity from NuGet `PackageId`. `Directory.Build.props` defines shared package metadata and `FluentMapPackageVersionPrefix` (currently `3.0.1`) with a local/dev suffix when no explicit version is supplied. `Directory.Build.targets` blocks unsafe historical package versions. Release behavior lives in the actual workflows under `.github/workflows/`; inspect them before changing or documenting release behavior.
+`eng/package-catalog.json` is the package identity catalog and separates project identity from NuGet `PackageId`. `Directory.Build.props` defines shared package metadata and `FluentMapPackageVersionPrefix` (currently `3.0.1`) with a local/dev suffix when no explicit version is supplied. The repository currently uses explicit `PackageReference` versions rather than Central Package Management. `Directory.Build.targets` blocks unsafe historical package versions. Release behavior lives in the actual workflows under `.github/workflows/`; inspect them before changing or documenting release behavior.
+
+NuGet.org publishing uses OIDC Trusted Publishing through `NuGet/login`, a protected `release` environment, and job-scoped `id-token: write`. Preserve this model; do not introduce a long-lived NuGet API key as a shortcut.
 
 Package or release changes require compatibility, provenance, artifact-set, rollback/recovery, and SemVer review. Do not alter PackageIds, versioning, authors, license, URLs, README/icon packaging, Source Link/provenance, or NuGet metadata without explicit scope.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ The historical archived package history is not reconstructed here. This changelo
 
 ### Added
 
+- ADR Guard local tooling and ADR documentation for the NuGet PackageId architecture decision.
+- A package catalog under `eng/package-catalog.json` as the authoritative distribution package inventory.
 - Public adoption documentation for README, migration, compatibility and support policy.
 - Release candidate readiness checklist under `.sdd/etapa-12/`.
 
 ### Changed
 
+- The new Dependency Injection, analyzer and generator NuGet PackageIds are now `FluentMap.DependencyInjection`, `FluentMap.Analyzers` and `FluentMap.Generators`. Project names, assemblies, namespaces and public APIs remain `Dapper.FluentMap.*`.
+- Release and recovery automation now distinguish package-version existence from publisher authorization, validate existing NuGet.org artifacts before accepting them and publish only genuinely missing packages.
 - README is now a concise bilingual entrypoint and delegates detailed release/adoption policy to dedicated documents.
 
 ## [3.0.0-rc.1] - Unreleased
@@ -32,7 +36,7 @@ Release candidate status: ready for publication qualification. The date remains
 
 ### Changed
 
-- Release versioning is hardened so default local pack produces `3.0.0-dev`, not historical `2.0.0` or accidental stable `3.0.0`.
+- Release versioning is hardened so default local pack produces `3.0.1-dev`, not historical `2.0.0` or accidental stable `3.0.0`.
 - Release workflow uses an explicit validated package version for RC artifacts.
 - Public mapping configuration can now be isolated through immutable configuration/runtime APIs while the legacy global facade remains available.
 - Dommel integration honors the new persistence metadata for supported write scenarios.
@@ -60,8 +64,8 @@ Release candidate status: ready for publication qualification. The date remains
 - Pin all FluentMap packages to the exact same prerelease version: `3.0.0-rc.1`.
 - Keep existing global `FluentMapper.Initialize` usage when source compatibility is the priority.
 - Prefer `FluentMapConfigurationBuilder` and `FluentMapRuntime` for new isolated configurations or DI-based composition.
-- Add `Dapper.FluentMap.DependencyInjection` only when using `Microsoft.Extensions.DependencyInjection`.
-- Add `Dapper.FluentMap.Analyzers` and `Dapper.FluentMap.Generators` as analyzer/compiler packages; they should not be consumed as runtime libraries.
+- Add `FluentMap.DependencyInjection` only when using `Microsoft.Extensions.DependencyInjection`.
+- Add `FluentMap.Analyzers` and `FluentMap.Generators` as analyzer/compiler packages; they should not be consumed as runtime libraries.
 - For Dommel, keep using `Dapper.FluentMap.Dommel` and verify key/default/computed/read-only metadata against real write scenarios before promoting from RC.
 
 ### Known Limitations

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,11 +8,13 @@ This document describes what is currently validated by this repository. It avoid
 | --- | --- | --- |
 | `Dapper.FluentMap` | `netstandard2.0` | Core package. |
 | `Dapper.FluentMap.Dommel` | `netstandard2.0` | Optional Dommel integration. |
-| `Dapper.FluentMap.DependencyInjection` | `netstandard2.0` | Optional DI integration. |
-| `Dapper.FluentMap.Analyzers` | `netstandard2.0` | Roslyn analyzer package. |
-| `Dapper.FluentMap.Generators` | `netstandard2.0` | Roslyn source generator package. |
+| `FluentMap.DependencyInjection` | `netstandard2.0` | Optional DI integration. |
+| `FluentMap.Analyzers` | `netstandard2.0` | Roslyn analyzer package. |
+| `FluentMap.Generators` | `netstandard2.0` | Roslyn source generator package. |
 
 Tests, provider compatibility tests, AOT smoke projects and benchmarks currently run on `net10.0`. That does not raise the minimum TFM for consumers.
+
+The `FluentMap.*` PackageIds are NuGet distribution identities. Assemblies and namespaces remain under `Dapper.FluentMap.*` for source and binary compatibility.
 
 ## Dapper
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <FluentMapPackageVersionPrefix Condition="'$(FluentMapPackageVersionPrefix)' == ''">3.0.0</FluentMapPackageVersionPrefix>
-    <FluentMapPackageVersionSuffix Condition="'$(Version)' == '' and '$(VersionSuffix)' == '' and '$(FluentMapPackageVersionPrefix)' == '3.0.0'">dev</FluentMapPackageVersionSuffix>
+    <FluentMapPackageVersionPrefix Condition="'$(FluentMapPackageVersionPrefix)' == ''">3.0.1</FluentMapPackageVersionPrefix>
+    <FluentMapPackageVersionSuffix Condition="'$(Version)' == '' and '$(VersionSuffix)' == '' and '$(FluentMapPackageVersionPrefix)' == '3.0.1'">dev</FluentMapPackageVersionSuffix>
     <VersionSuffix Condition="'$(FluentMapPackageVersionSuffix)' != '' and '$(VersionSuffix)' == ''">$(FluentMapPackageVersionSuffix)</VersionSuffix>
     <DapperMinimumSupportedVersion>2.1.79</DapperMinimumSupportedVersion>
     <DapperLatestStableVersion>2.1.79</DapperLatestStableVersion>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,6 +1,8 @@
 <Project>
-  <Target Name="BlockUnsafeFluentMapPackageVersions" BeforeTargets="Pack" Condition="'$(IsPackable)' != 'false'">
+  <Target Name="BlockUnsafeFluentMapPackageVersions" BeforeTargets="GenerateNuspec" Condition="'$(IsPackable)' != 'false'">
     <Error Condition="'$(PackageVersion)' == '2.0.0' or ('$(PackageVersion)' == '' and '$(Version)' == '2.0.0')"
            Text="Version 2.0.0 already exists for historical FluentMap package IDs and must not be produced by this repository." />
+    <Error Condition="'$(PackageVersion)' == '3.0.0' or ('$(PackageVersion)' == '' and '$(Version)' == '3.0.0')"
+           Text="Version 3.0.0 contains immutable historical FluentMap artifacts and must not be produced by newer repository commits." />
   </Target>
 </Project>

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -45,9 +45,11 @@ Install only the packages you use:
 | --- | --- |
 | `Dapper.FluentMap` | Core mapping and Dapper integration. |
 | `Dapper.FluentMap.Dommel` | Dommel table/key/generated-column integration. |
-| `Dapper.FluentMap.DependencyInjection` | DI registration of immutable configuration and runtime. |
-| `Dapper.FluentMap.Analyzers` | Compile-time diagnostics for mapping mistakes. |
-| `Dapper.FluentMap.Generators` | Generated registration and supported generated materializers. |
+| `FluentMap.DependencyInjection` | DI registration of immutable configuration and runtime. |
+| `FluentMap.Analyzers` | Compile-time diagnostics for mapping mistakes. |
+| `FluentMap.Generators` | Generated registration and supported generated materializers. |
+
+The three `FluentMap.*` PackageIds replace the unpublished `Dapper.FluentMap.DependencyInjection`, `Dapper.FluentMap.Analyzers` and `Dapper.FluentMap.Generators` distribution identities. This is not a namespace, assembly or API rename; keep existing `using Dapper.FluentMap.*` directives.
 
 ## Initialize
 
@@ -212,7 +214,7 @@ Write converter metadata exists, but Dapper/Dommel writes do not execute it yet.
 
 ## Generated Registration
 
-Install `Dapper.FluentMap.Generators` and call:
+Install `FluentMap.Generators` and call:
 
 ```csharp
 config.AddGeneratedMappings();
@@ -239,7 +241,7 @@ This isolates FluentMap-controlled materialization. It does not isolate normal `
 
 ## DI
 
-Install `Dapper.FluentMap.DependencyInjection` and register:
+Install `FluentMap.DependencyInjection` and register:
 
 ```csharp
 services.AddFluentMap(builder =>

--- a/README.md
+++ b/README.md
@@ -69,17 +69,23 @@ Do not use FluentMap as an ORM, CRUD framework, query builder, unit of work, or 
 
 Install the package that matches the feature set you need:
 
-| Package | Purpose |
+| Package purpose | NuGet PackageId |
 | --- | --- |
-| `Dapper.FluentMap` | Core mapping API and Dapper integration. |
-| `Dapper.FluentMap.Dommel` | Optional Dommel integration for table, key and generated-column mapping. |
-| `Dapper.FluentMap.DependencyInjection` | Optional `Microsoft.Extensions.DependencyInjection` integration. |
-| `Dapper.FluentMap.Analyzers` | Roslyn analyzers for statically provable mapping mistakes. |
-| `Dapper.FluentMap.Generators` | Source generator for build-time map registration and generated materializers. |
+| Core | `Dapper.FluentMap` |
+| Dommel integration | `Dapper.FluentMap.Dommel` |
+| Dependency Injection | `FluentMap.DependencyInjection` |
+| Roslyn analyzers | `FluentMap.Analyzers` |
+| Source generators | `FluentMap.Generators` |
 
 ```bash
 dotnet add package Dapper.FluentMap
+dotnet add package Dapper.FluentMap.Dommel
+dotnet add package FluentMap.DependencyInjection
+dotnet add package FluentMap.Analyzers
+dotnet add package FluentMap.Generators
 ```
+
+The `FluentMap.*` PackageIds are distribution identities only. They do not rename the existing assemblies, C# namespaces or public APIs.
 
 The public packages target `netstandard2.0`. See [COMPATIBILITY.md](COMPATIBILITY.md) before adopting a release candidate.
 
@@ -268,10 +274,10 @@ Profiles are selected per FluentMap-controlled query. They do not replace the gl
 
 ## Generated Materialization
 
-Install `Dapper.FluentMap.Generators` when you want generated registration for maps in the current compilation:
+Install `FluentMap.Generators` when you want generated registration for maps in the current compilation:
 
 ```bash
-dotnet add package Dapper.FluentMap.Generators
+dotnet add package FluentMap.Generators
 ```
 
 Then call the generated extension:
@@ -414,7 +420,11 @@ var customer = runtime.QueryMappedSingle<Customer>(
     "SELECT 7 AS customer_id, 'Ada' AS Name;");
 ```
 
-Install `Dapper.FluentMap.DependencyInjection` for DI registration:
+Install `FluentMap.DependencyInjection` for DI registration:
+
+```bash
+dotnet add package FluentMap.DependencyInjection
+```
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -69,17 +69,23 @@ Não use FluentMap como ORM, framework CRUD, query builder, unit of work ou abst
 
 Instale o pacote que corresponde ao recurso necessário:
 
-| Pacote | Finalidade |
+| Finalidade do pacote | NuGet PackageId |
 | --- | --- |
-| `Dapper.FluentMap` | API core de mapping e integração com Dapper. |
-| `Dapper.FluentMap.Dommel` | Integração opcional com Dommel para tabela, chave e colunas geradas. |
-| `Dapper.FluentMap.DependencyInjection` | Integração opcional com `Microsoft.Extensions.DependencyInjection`. |
-| `Dapper.FluentMap.Analyzers` | Analyzers Roslyn para erros de configuração prováveis em tempo de compilação. |
-| `Dapper.FluentMap.Generators` | Source generator para registro de maps e materializadores gerados. |
+| Core | `Dapper.FluentMap` |
+| Integração Dommel | `Dapper.FluentMap.Dommel` |
+| Dependency Injection | `FluentMap.DependencyInjection` |
+| Analyzers Roslyn | `FluentMap.Analyzers` |
+| Source generators | `FluentMap.Generators` |
 
 ```bash
 dotnet add package Dapper.FluentMap
+dotnet add package Dapper.FluentMap.Dommel
+dotnet add package FluentMap.DependencyInjection
+dotnet add package FluentMap.Analyzers
+dotnet add package FluentMap.Generators
 ```
+
+Os PackageIds `FluentMap.*` são apenas identidades de distribuição. Eles não renomeiam assemblies, namespaces C# ou APIs públicas existentes.
 
 Os pacotes públicos targetam `netstandard2.0`. Consulte [COMPATIBILITY.md](COMPATIBILITY.md) antes de adotar um release candidate.
 
@@ -268,10 +274,10 @@ Profiles são selecionados por query controlada pelo FluentMap. Eles não substi
 
 ## Materialização Gerada
 
-Instale `Dapper.FluentMap.Generators` para registro gerado de maps da compilação atual:
+Instale `FluentMap.Generators` para registro gerado de maps da compilação atual:
 
 ```bash
-dotnet add package Dapper.FluentMap.Generators
+dotnet add package FluentMap.Generators
 ```
 
 Depois chame a extensão gerada:
@@ -414,7 +420,11 @@ var customer = runtime.QueryMappedSingle<Customer>(
     "SELECT 7 AS customer_id, 'Ada' AS Name;");
 ```
 
-Instale `Dapper.FluentMap.DependencyInjection` para registro em DI:
+Instale `FluentMap.DependencyInjection` para registro em DI:
+
+```bash
+dotnet add package FluentMap.DependencyInjection
+```
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/docs/adr/0001-decouple-nuget-package-ids-from-fluentmap-project-identities.md
+++ b/docs/adr/0001-decouple-nuget-package-ids-from-fluentmap-project-identities.md
@@ -1,0 +1,79 @@
+# Decouple NuGet Package IDs from FluentMap project identities
+
+## Status
+
+Accepted
+
+## Context
+
+FluentMap publishes multiple NuGet packages from one repository. Historically the NuGet PackageId, project name, assembly name, directory name and C# namespace often used the same text. That similarity is convenient, but it is not a technical requirement.
+
+During publication of version 3.0.0, NuGet.org accepted `Dapper.FluentMap` and `Dapper.FluentMap.Dommel`, then rejected creation of `Dapper.FluentMap.DependencyInjection` with HTTP 409 because the `Dapper.FluentMap.*` package prefix is reserved. Trusted Publishing/OIDC authentication had already succeeded. The failure was not caused by invalid credentials, OIDC configuration, package corruption, build failure, test failure, checksum failure or a duplicate version of the new DependencyInjection package.
+
+The same namespace constraint can affect other newly introduced PackageIds under `Dapper.FluentMap.*`, including analyzers and source generators.
+
+A NuGet flat-container HTTP 404 proves only that a particular PackageId/version is not currently published. It does not prove that the authenticated publisher is authorized to create that PackageId under a reserved prefix.
+
+The 3.0.0 artifacts already accepted by NuGet.org are immutable historical artifacts:
+
+- `Dapper.FluentMap` 3.0.0
+- `Dapper.FluentMap.Dommel` 3.0.0
+
+The repository must not delete, recreate, move, force-update or retag `v3.0.0`, and it must not create new 3.0.0 packages from a newer commit to fill the previous partial release.
+
+## Decision
+
+We will decouple only the distribution identities that are blocked by NuGet.org prefix reservation. Existing package identities that were already accepted remain unchanged:
+
+| Project / Assembly | NuGet PackageId |
+| --- | --- |
+| `Dapper.FluentMap` | `Dapper.FluentMap` |
+| `Dapper.FluentMap.Dommel` | `Dapper.FluentMap.Dommel` |
+| `Dapper.FluentMap.DependencyInjection` | `FluentMap.DependencyInjection` |
+| `Dapper.FluentMap.Analyzers` | `FluentMap.Analyzers` |
+| `Dapper.FluentMap.Generators` | `FluentMap.Generators` |
+
+Project identity, assembly identity, namespace identity and NuGet PackageId are independent identities:
+
+```text
+Project identity != Assembly identity != Namespace identity != NuGet PackageId
+```
+
+The repository will preserve source and binary identities for the three renamed distribution packages:
+
+- `src/Dapper.FluentMap.DependencyInjection/`
+- `Dapper.FluentMap.DependencyInjection.csproj`
+- `Dapper.FluentMap.DependencyInjection.dll`
+- `namespace Dapper.FluentMap.DependencyInjection`
+- `src/Dapper.FluentMap.Analyzers/`
+- `Dapper.FluentMap.Analyzers.csproj`
+- `Dapper.FluentMap.Analyzers.dll`
+- `namespace Dapper.FluentMap.Analyzers`
+- `src/Dapper.FluentMap.Generators/`
+- `Dapper.FluentMap.Generators.csproj`
+- `Dapper.FluentMap.Generators.dll`
+- `namespace Dapper.FluentMap.Generators`
+
+Package identity will be managed through a single machine-readable catalog under `eng/`. Release, recovery, metadata validation and consumer smoke tests should use that catalog wherever practical.
+
+The next coherent release after this decision should be 3.0.1 for the complete package family:
+
+- `Dapper.FluentMap`
+- `Dapper.FluentMap.Dommel`
+- `FluentMap.DependencyInjection`
+- `FluentMap.Analyzers`
+- `FluentMap.Generators`
+
+This decision prepares the repository for 3.0.1. It does not publish packages, create `v3.0.1` or create a GitHub Release.
+
+## Consequences
+
+Consumers install the three new feature packages through their new NuGet identities while continuing to use the existing C# namespaces and public APIs.
+
+Analyzer and source-generator packages intentionally keep their assembly names inside the analyzer package layout. For example, `FluentMap.Analyzers` can contain `analyzers/dotnet/cs/Dapper.FluentMap.Analyzers.dll`.
+
+Release preflight must distinguish "PackageId/version is not currently published" from "the publisher is authorized to create the PackageId." Unexpected NuGet responses must fail closed.
+
+Release and recovery workflows must treat partial publication as recoverable by explicitly checking which PackageId/version pairs already exist, validating existing packages before accepting them and publishing only packages that are genuinely missing. They must not use `--skip-duplicate`, hide the original `dotnet nuget push` diagnostic, move existing tags or mask artifact mismatches.
+
+Documentation must explain the PackageId change as a distribution identity change, not a namespace rename, assembly rename or public API breaking change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| ADR | Decision | Status |
+| --- | --- | --- |
+| [0001](0001-decouple-nuget-package-ids-from-fluentmap-project-identities.md) | Decouple NuGet Package IDs from FluentMap project identities | Accepted |

--- a/eng/PackageCatalog.psm1
+++ b/eng/PackageCatalog.psm1
@@ -1,0 +1,134 @@
+Set-StrictMode -Version Latest
+
+function Get-FluentMapPackageCatalog {
+  [CmdletBinding()]
+  param(
+    [string]$CatalogPath
+  )
+
+  if ([string]::IsNullOrWhiteSpace($CatalogPath)) {
+    $CatalogPath = Join-Path $PSScriptRoot 'package-catalog.json'
+  }
+
+  if (-not (Test-Path -LiteralPath $CatalogPath -PathType Leaf)) {
+    throw "Package catalog '$CatalogPath' does not exist."
+  }
+
+  $catalog = Get-Content -LiteralPath $CatalogPath -Raw | ConvertFrom-Json
+  if ($catalog.schemaVersion -ne '1.0') {
+    throw "Package catalog '$CatalogPath' has unsupported schemaVersion '$($catalog.schemaVersion)'."
+  }
+
+  $packages = @($catalog.packages)
+  if ($packages.Count -eq 0) {
+    throw "Package catalog '$CatalogPath' does not define any packages."
+  }
+
+  $duplicateProjects = @(
+    $packages |
+      Group-Object project |
+      Where-Object { $_.Count -gt 1 } |
+      ForEach-Object { $_.Name }
+  )
+  if ($duplicateProjects.Count -gt 0) {
+    throw "Package catalog '$CatalogPath' contains duplicate project identities: $($duplicateProjects -join ', ')."
+  }
+
+  $duplicatePackageIds = @(
+    $packages |
+      Group-Object packageId |
+      Where-Object { $_.Count -gt 1 } |
+      ForEach-Object { $_.Name }
+  )
+  if ($duplicatePackageIds.Count -gt 0) {
+    throw "Package catalog '$CatalogPath' contains duplicate package identities: $($duplicatePackageIds -join ', ')."
+  }
+
+  foreach ($package in $packages) {
+    foreach ($propertyName in @('project', 'projectPath', 'packageId', 'assetKind')) {
+      if ([string]::IsNullOrWhiteSpace([string]$package.$propertyName)) {
+        throw "Package catalog '$CatalogPath' contains a package with missing '$propertyName'."
+      }
+    }
+
+    if ($package.assetKind -notin @('library', 'analyzer')) {
+      throw "Package catalog '$CatalogPath' contains unsupported assetKind '$($package.assetKind)' for '$($package.project)'."
+    }
+  }
+
+  return $catalog
+}
+
+function Get-FluentMapPackages {
+  [CmdletBinding()]
+  param(
+    [string]$CatalogPath,
+
+    [ValidateSet('library', 'analyzer')]
+    [string]$AssetKind,
+
+    [switch]$WithSymbols
+  )
+
+  $packages = @((Get-FluentMapPackageCatalog -CatalogPath $CatalogPath).packages)
+
+  if (-not [string]::IsNullOrWhiteSpace($AssetKind)) {
+    $packages = @($packages | Where-Object { $_.assetKind -eq $AssetKind })
+  }
+
+  if ($PSBoundParameters.ContainsKey('WithSymbols')) {
+    $packages = @($packages | Where-Object { [bool]$_.symbols })
+  }
+
+  return $packages
+}
+
+function Get-FluentMapPackageIds {
+  [CmdletBinding()]
+  param(
+    [string]$CatalogPath,
+
+    [ValidateSet('library', 'analyzer')]
+    [string]$AssetKind,
+
+    [switch]$WithSymbols
+  )
+
+  $arguments = @{
+    CatalogPath = $CatalogPath
+  }
+
+  if ($PSBoundParameters.ContainsKey('AssetKind')) {
+    $arguments.AssetKind = $AssetKind
+  }
+
+  if ($PSBoundParameters.ContainsKey('WithSymbols')) {
+    $arguments.WithSymbols = $true
+  }
+
+  return @(Get-FluentMapPackages @arguments | ForEach-Object { [string]$_.packageId })
+}
+
+function Get-FluentMapPackageFileName {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory = $true)]
+    [pscustomobject]$Package,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [ValidateSet('package', 'symbols')]
+    [string]$Kind = 'package'
+  )
+
+  $extension = if ($Kind -eq 'symbols') { 'snupkg' } else { 'nupkg' }
+  return "$($Package.packageId).$Version.$extension"
+}
+
+Export-ModuleMember `
+  -Function `
+    Get-FluentMapPackageCatalog, `
+    Get-FluentMapPackages, `
+    Get-FluentMapPackageIds, `
+    Get-FluentMapPackageFileName

--- a/eng/consumer-smoke/AnalyzerDiagnosticConsumer/AnalyzerDiagnosticConsumer.csproj
+++ b/eng/consumer-smoke/AnalyzerDiagnosticConsumer/AnalyzerDiagnosticConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.0-rc.1" />
-    <PackageReference Include="Dapper.FluentMap.Analyzers" Version="3.0.0-rc.1" PrivateAssets="all" />
+    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
+    <PackageReference Include="FluentMap.Analyzers" Version="3.0.1" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/consumer-smoke/AnalyzerDiagnosticConsumer/AnalyzerDiagnosticConsumer.csproj
+++ b/eng/consumer-smoke/AnalyzerDiagnosticConsumer/AnalyzerDiagnosticConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
-    <PackageReference Include="FluentMap.Analyzers" Version="3.0.1" PrivateAssets="all" />
+    <PackageReference Include="Dapper.FluentMap" Version="$(FluentMapConsumerSmokePackageVersion)" />
+    <PackageReference Include="FluentMap.Analyzers" Version="$(FluentMapConsumerSmokePackageVersion)" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/eng/consumer-smoke/CoreConsumer/CoreConsumer.csproj
+++ b/eng/consumer-smoke/CoreConsumer/CoreConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.0-rc.1" />
+    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />
   </ItemGroup>

--- a/eng/consumer-smoke/CoreConsumer/CoreConsumer.csproj
+++ b/eng/consumer-smoke/CoreConsumer/CoreConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
+    <PackageReference Include="Dapper.FluentMap" Version="$(FluentMapConsumerSmokePackageVersion)" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />
   </ItemGroup>

--- a/eng/consumer-smoke/DIConsumer/DIConsumer.csproj
+++ b/eng/consumer-smoke/DIConsumer/DIConsumer.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap.DependencyInjection" Version="3.0.0-rc.1" />
-    <PackageReference Include="Dapper.FluentMap.Generators" Version="3.0.0-rc.1" PrivateAssets="all" />
+    <PackageReference Include="FluentMap.DependencyInjection" Version="3.0.1" />
+    <PackageReference Include="FluentMap.Generators" Version="3.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />

--- a/eng/consumer-smoke/DIConsumer/DIConsumer.csproj
+++ b/eng/consumer-smoke/DIConsumer/DIConsumer.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="FluentMap.DependencyInjection" Version="3.0.1" />
-    <PackageReference Include="FluentMap.Generators" Version="3.0.1" PrivateAssets="all" />
+    <PackageReference Include="FluentMap.DependencyInjection" Version="$(FluentMapConsumerSmokePackageVersion)" />
+    <PackageReference Include="FluentMap.Generators" Version="$(FluentMapConsumerSmokePackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />

--- a/eng/consumer-smoke/Directory.Build.props
+++ b/eng/consumer-smoke/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <FluentMapConsumerSmokePackageVersion Condition="'$(FluentMapConsumerSmokePackageVersion)' == ''">3.0.1</FluentMapConsumerSmokePackageVersion>
+  </PropertyGroup>
+</Project>

--- a/eng/consumer-smoke/DommelConsumer/DommelConsumer.csproj
+++ b/eng/consumer-smoke/DommelConsumer/DommelConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap.Dommel" Version="3.0.0-rc.1" />
+    <PackageReference Include="Dapper.FluentMap.Dommel" Version="3.0.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />
   </ItemGroup>

--- a/eng/consumer-smoke/DommelConsumer/DommelConsumer.csproj
+++ b/eng/consumer-smoke/DommelConsumer/DommelConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap.Dommel" Version="3.0.1" />
+    <PackageReference Include="Dapper.FluentMap.Dommel" Version="$(FluentMapConsumerSmokePackageVersion)" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />
   </ItemGroup>

--- a/eng/consumer-smoke/GeneratorAnalyzerConsumer/GeneratorAnalyzerConsumer.csproj
+++ b/eng/consumer-smoke/GeneratorAnalyzerConsumer/GeneratorAnalyzerConsumer.csproj
@@ -9,9 +9,9 @@
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.0-rc.1" />
-    <PackageReference Include="Dapper.FluentMap.Analyzers" Version="3.0.0-rc.1" PrivateAssets="all" />
-    <PackageReference Include="Dapper.FluentMap.Generators" Version="3.0.0-rc.1" PrivateAssets="all" />
+    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
+    <PackageReference Include="FluentMap.Analyzers" Version="3.0.1" PrivateAssets="all" />
+    <PackageReference Include="FluentMap.Generators" Version="3.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />
   </ItemGroup>

--- a/eng/consumer-smoke/GeneratorAnalyzerConsumer/GeneratorAnalyzerConsumer.csproj
+++ b/eng/consumer-smoke/GeneratorAnalyzerConsumer/GeneratorAnalyzerConsumer.csproj
@@ -9,9 +9,9 @@
     <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)generated</CompilerGeneratedFilesOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
-    <PackageReference Include="FluentMap.Analyzers" Version="3.0.1" PrivateAssets="all" />
-    <PackageReference Include="FluentMap.Generators" Version="3.0.1" PrivateAssets="all" />
+    <PackageReference Include="Dapper.FluentMap" Version="$(FluentMapConsumerSmokePackageVersion)" />
+    <PackageReference Include="FluentMap.Analyzers" Version="$(FluentMapConsumerSmokePackageVersion)" PrivateAssets="all" />
+    <PackageReference Include="FluentMap.Generators" Version="$(FluentMapConsumerSmokePackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" PrivateAssets="all" />
   </ItemGroup>

--- a/eng/consumer-smoke/TrimExplicitConsumer/TrimExplicitConsumer.csproj
+++ b/eng/consumer-smoke/TrimExplicitConsumer/TrimExplicitConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.0-rc.1" />
+    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>

--- a/eng/consumer-smoke/TrimExplicitConsumer/TrimExplicitConsumer.csproj
+++ b/eng/consumer-smoke/TrimExplicitConsumer/TrimExplicitConsumer.csproj
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
+    <PackageReference Include="Dapper.FluentMap" Version="$(FluentMapConsumerSmokePackageVersion)" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>

--- a/eng/consumer-smoke/TrimGeneratedConsumer/TrimGeneratedConsumer.csproj
+++ b/eng/consumer-smoke/TrimGeneratedConsumer/TrimGeneratedConsumer.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.0-rc.1" />
-    <PackageReference Include="Dapper.FluentMap.Generators" Version="3.0.0-rc.1" PrivateAssets="all" />
+    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
+    <PackageReference Include="FluentMap.Generators" Version="3.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>

--- a/eng/consumer-smoke/TrimGeneratedConsumer/TrimGeneratedConsumer.csproj
+++ b/eng/consumer-smoke/TrimGeneratedConsumer/TrimGeneratedConsumer.csproj
@@ -7,8 +7,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper.FluentMap" Version="3.0.1" />
-    <PackageReference Include="FluentMap.Generators" Version="3.0.1" PrivateAssets="all" />
+    <PackageReference Include="Dapper.FluentMap" Version="$(FluentMapConsumerSmokePackageVersion)" />
+    <PackageReference Include="FluentMap.Generators" Version="$(FluentMapConsumerSmokePackageVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.12" />
   </ItemGroup>

--- a/eng/consumer-smoke/run-consumer-smoke.ps1
+++ b/eng/consumer-smoke/run-consumer-smoke.ps1
@@ -3,20 +3,18 @@ param(
   [string]$RepositoryRoot,
   [string]$RemoteArtifactDirectory,
   [string]$PackageDirectory,
+  [string]$PackageVersion,
   [switch]$SkipTrimPublish
 )
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
-$packageVersion = '3.0.0-rc.1'
-$expectedPackageIds = @(
-  'Dapper.FluentMap',
-  'Dapper.FluentMap.Dommel',
-  'Dapper.FluentMap.DependencyInjection',
-  'Dapper.FluentMap.Analyzers',
-  'Dapper.FluentMap.Generators'
-)
+Import-Module (Join-Path $PSScriptRoot '../PackageCatalog.psm1') -Force
+
+$packageVersion = if ([string]::IsNullOrWhiteSpace($PackageVersion)) { '3.0.1' } else { $PackageVersion }
+$catalogPackages = @(Get-FluentMapPackages)
+$expectedPackageIds = @($catalogPackages | ForEach-Object { [string]$_.packageId })
 
 function Fail {
   param([string]$Message)
@@ -188,6 +186,7 @@ function Write-NuGetConfig {
     <packageSource key="rc-artifacts">
       <package pattern="Dapper.FluentMap" />
       <package pattern="Dapper.FluentMap.*" />
+      <package pattern="FluentMap.*" />
     </packageSource>
     <packageSource key="nuget.org">
       <package pattern="Dapper" />
@@ -246,7 +245,7 @@ function Assert-RestoredPackages {
   }
 
   $wrongFluentMapVersions = @($libraryNames | Where-Object {
-      $_ -match '^Dapper\.FluentMap(\..*)?/' -and $_ -notmatch "/$([regex]::Escape($packageVersion))$"
+      $_ -match '^(Dapper\.FluentMap(\..*)?|FluentMap\..*)/' -and $_ -notmatch "/$([regex]::Escape($packageVersion))$"
     })
   if ($wrongFluentMapVersions.Count -gt 0) {
     Fail "$ProjectPath restored unexpected FluentMap versions: $($wrongFluentMapVersions -join ', ')."
@@ -262,7 +261,7 @@ function Assert-RestoredPackages {
     Fail "$ProjectPath restored project libraries: $($projectLibraries.Name -join ', ')."
   }
 
-  foreach ($analyzerId in @('Dapper.FluentMap.Analyzers', 'Dapper.FluentMap.Generators')) {
+  foreach ($analyzerId in @($catalogPackages | Where-Object { $_.assetKind -eq 'analyzer' } | ForEach-Object { [string]$_.packageId })) {
     $targetLibraryNames = @(
       foreach ($target in $assets.targets.PSObject.Properties) {
         foreach ($library in $target.Value.PSObject.Properties) {
@@ -349,7 +348,7 @@ function Invoke-DotNetForProject {
 $repoRoot = Get-RepoRoot
 $artifactFiles = @{}
 if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
-  $releaseDirectory = Join-Path $repoRoot '.sdd/release-3.0.0-rc.1'
+  $releaseDirectory = Join-Path $repoRoot '.sdd/release-3.0.1'
   $manifestPath = Join-Path $releaseDirectory 'artifacts.json'
   if (-not (Test-Path -LiteralPath $manifestPath)) {
     Fail "Manifest not found at '$manifestPath'."
@@ -361,7 +360,7 @@ if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
   }
 
   $remoteRoot = if ([string]::IsNullOrWhiteSpace($RemoteArtifactDirectory)) {
-    Join-Path $repoRoot 'artifacts/release-3.0.0-rc.1/remote'
+    Join-Path $repoRoot 'artifacts/release-3.0.1/remote'
   }
   else {
     $RemoteArtifactDirectory
@@ -414,12 +413,12 @@ $projects = @(
   [pscustomobject]@{
     Name = 'GeneratorAnalyzerConsumer'
     Path = Join-Path $PSScriptRoot 'GeneratorAnalyzerConsumer/GeneratorAnalyzerConsumer.csproj'
-    Packages = @('Dapper.FluentMap', 'Dapper.FluentMap.Analyzers', 'Dapper.FluentMap.Generators')
+    Packages = @('Dapper.FluentMap', 'FluentMap.Analyzers', 'FluentMap.Generators')
   },
   [pscustomobject]@{
     Name = 'DIConsumer'
     Path = Join-Path $PSScriptRoot 'DIConsumer/DIConsumer.csproj'
-    Packages = @('Dapper.FluentMap', 'Dapper.FluentMap.DependencyInjection', 'Dapper.FluentMap.Generators')
+    Packages = @('Dapper.FluentMap', 'FluentMap.DependencyInjection', 'FluentMap.Generators')
   },
   [pscustomobject]@{
     Name = 'DommelConsumer'
@@ -474,7 +473,7 @@ Invoke-DotNetForProject `
   -LogPath (Join-Path $logsDirectory 'AnalyzerDiagnosticConsumer.restore.log') | Out-Null
 Assert-RestoredPackages `
   -ProjectPath $analyzerDiagnosticProject `
-  -ExpectedFluentMapPackages @('Dapper.FluentMap', 'Dapper.FluentMap.Analyzers') `
+  -ExpectedFluentMapPackages @('Dapper.FluentMap', 'FluentMap.Analyzers') `
   -PackagesDirectory $packagesDirectory
 
 $diagnosticResult = Invoke-DotNetForProject `
@@ -508,7 +507,7 @@ if (-not $SkipTrimPublish) {
       -ExtraArguments @('--runtime', $rid) | Out-Null
 
     $trimExpectedPackages = if ($trimProjectName -eq 'TrimGeneratedConsumer') {
-      @('Dapper.FluentMap', 'Dapper.FluentMap.Generators')
+      @('Dapper.FluentMap', 'FluentMap.Generators')
     }
     else {
       @('Dapper.FluentMap')

--- a/eng/consumer-smoke/run-consumer-smoke.ps1
+++ b/eng/consumer-smoke/run-consumer-smoke.ps1
@@ -309,6 +309,7 @@ function Invoke-DotNetForProject {
         $ConfigPath,
         '-p:RestoreNoCache=true',
         "-p:RestorePackagesPath=$PackagesDirectory",
+        "-p:FluentMapConsumerSmokePackageVersion=$packageVersion",
         '-p:DisableImplicitNuGetFallbackFolder=true'
       ) + $ExtraArguments
     }
@@ -317,6 +318,7 @@ function Invoke-DotNetForProject {
         'build',
         $ProjectPath,
         "-p:RestorePackagesPath=$PackagesDirectory",
+        "-p:FluentMapConsumerSmokePackageVersion=$packageVersion",
         '-p:DisableImplicitNuGetFallbackFolder=true'
       ) + $ExtraArguments
     }
@@ -326,6 +328,7 @@ function Invoke-DotNetForProject {
         '--project',
         $ProjectPath,
         "--property:RestorePackagesPath=$PackagesDirectory",
+        "--property:FluentMapConsumerSmokePackageVersion=$packageVersion",
         '--property:DisableImplicitNuGetFallbackFolder=true'
       ) + $ExtraArguments
     }
@@ -334,6 +337,7 @@ function Invoke-DotNetForProject {
         'publish',
         $ProjectPath,
         "-p:RestorePackagesPath=$PackagesDirectory",
+        "-p:FluentMapConsumerSmokePackageVersion=$packageVersion",
         '-p:DisableImplicitNuGetFallbackFolder=true'
       ) + $ExtraArguments
     }

--- a/eng/package-catalog.json
+++ b/eng/package-catalog.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": "1.0",
+  "packages": [
+    {
+      "project": "Dapper.FluentMap",
+      "projectPath": "src/Dapper.FluentMap/Dapper.FluentMap.csproj",
+      "packageId": "Dapper.FluentMap",
+      "assetKind": "library",
+      "symbols": true
+    },
+    {
+      "project": "Dapper.FluentMap.Dommel",
+      "projectPath": "src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj",
+      "packageId": "Dapper.FluentMap.Dommel",
+      "assetKind": "library",
+      "symbols": true
+    },
+    {
+      "project": "Dapper.FluentMap.DependencyInjection",
+      "projectPath": "src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj",
+      "packageId": "FluentMap.DependencyInjection",
+      "assetKind": "library",
+      "symbols": true
+    },
+    {
+      "project": "Dapper.FluentMap.Analyzers",
+      "projectPath": "src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj",
+      "packageId": "FluentMap.Analyzers",
+      "assetKind": "analyzer",
+      "symbols": false
+    },
+    {
+      "project": "Dapper.FluentMap.Generators",
+      "projectPath": "src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj",
+      "packageId": "FluentMap.Generators",
+      "assetKind": "analyzer",
+      "symbols": false
+    }
+  ]
+}

--- a/eng/publish-package-set.ps1
+++ b/eng/publish-package-set.ps1
@@ -24,6 +24,7 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
 Import-Module (Join-Path $PSScriptRoot 'PackageCatalog.psm1') -Force
+Add-Type -AssemblyName System.IO.Compression.FileSystem
 
 function Fail {
   param([string]$Message)
@@ -66,6 +67,87 @@ function Get-HttpStatus {
   return $status
 }
 
+function Test-IsRepositorySignatureEntry {
+  param([string]$EntryName)
+
+  $normalized = $EntryName.Replace('\', '/')
+  return $normalized.Equals('[Content_Types].xml', [System.StringComparison]::OrdinalIgnoreCase) -or
+    $normalized.Equals('_rels/.rels', [System.StringComparison]::OrdinalIgnoreCase) -or
+    $normalized.Equals('.signature.p7s', [System.StringComparison]::OrdinalIgnoreCase) -or
+    $normalized.StartsWith('package/services/digital-signature/', [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+function Get-NuGetPackageEntryHashes {
+  param([string]$PackagePath)
+
+  $entries = [ordered]@{}
+  $archive = [System.IO.Compression.ZipFile]::OpenRead($PackagePath)
+  try {
+    foreach ($entry in @($archive.Entries | Sort-Object -Property FullName)) {
+      if ([string]::IsNullOrEmpty($entry.Name) -or (Test-IsRepositorySignatureEntry -EntryName $entry.FullName)) {
+        continue
+      }
+
+      if ($entries.Contains($entry.FullName)) {
+        Fail "Package '$PackagePath' contains duplicate entry '$($entry.FullName)'."
+      }
+
+      $stream = $entry.Open()
+      $sha256 = [System.Security.Cryptography.SHA256]::Create()
+      try {
+        $entries[$entry.FullName] = [System.Convert]::ToHexString($sha256.ComputeHash($stream)).ToLowerInvariant()
+      }
+      finally {
+        $sha256.Dispose()
+        $stream.Dispose()
+      }
+    }
+  }
+  finally {
+    $archive.Dispose()
+  }
+
+  return $entries
+}
+
+function Assert-NuGetPackagesHaveSameContent {
+  param(
+    [string]$PackageId,
+    [string]$LocalPackagePath,
+    [string]$DownloadedPackagePath
+  )
+
+  $localEntries = Get-NuGetPackageEntryHashes -PackagePath $LocalPackagePath
+  $remoteEntries = Get-NuGetPackageEntryHashes -PackagePath $DownloadedPackagePath
+
+  $missingEntries = @($localEntries.Keys | Where-Object { -not $remoteEntries.Contains($_) })
+  $unexpectedEntries = @($remoteEntries.Keys | Where-Object { -not $localEntries.Contains($_) })
+  $changedEntries = @(
+    foreach ($entryName in $localEntries.Keys) {
+      if ($remoteEntries.Contains($entryName) -and $remoteEntries[$entryName] -ne $localEntries[$entryName]) {
+        $entryName
+      }
+    }
+  )
+
+  if ($missingEntries.Count -gt 0 -or $unexpectedEntries.Count -gt 0 -or $changedEntries.Count -gt 0) {
+    $details = @()
+    if ($missingEntries.Count -gt 0) {
+      $details += "missing entries: $($missingEntries -join ', ')"
+    }
+
+    if ($unexpectedEntries.Count -gt 0) {
+      $details += "unexpected entries: $($unexpectedEntries -join ', ')"
+    }
+
+    if ($changedEntries.Count -gt 0) {
+      $details += "changed entries: $($changedEntries -join ', ')"
+    }
+
+    Fail "NuGet.org already has $PackageId $Version, but the downloaded package content does not match the local artifact ($($details -join '; ')). Refusing to mask an artifact mismatch."
+  }
+}
+
 function Assert-NuGetOrgPackageMatches {
   param(
     [string]$PackageId,
@@ -95,13 +177,12 @@ function Assert-NuGetOrgPackageMatches {
       Fail "Unable to download existing NuGet.org package $PackageId $Version for artifact comparison."
     }
 
-    $localHash = (Get-FileHash -LiteralPath $LocalPackagePath -Algorithm SHA256).Hash.ToLowerInvariant()
-    $remoteHash = (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant()
-    if ($localHash -ne $remoteHash) {
-      Fail "NuGet.org already has $PackageId $Version, but its SHA-256 '$remoteHash' does not match local artifact '$localHash'. Refusing to mask an artifact mismatch."
-    }
+    Assert-NuGetPackagesHaveSameContent `
+      -PackageId $PackageId `
+      -LocalPackagePath $LocalPackagePath `
+      -DownloadedPackagePath $downloadPath
 
-    Write-Output "NuGet.org: validated existing $PackageId $Version against the local artifact hash; skipping push."
+    Write-Output "NuGet.org: validated existing $PackageId $Version against local artifact content while accounting for repository signatures; skipping push."
   }
   finally {
     if (Test-Path -LiteralPath $downloadPath) {

--- a/eng/publish-package-set.ps1
+++ b/eng/publish-package-set.ps1
@@ -1,0 +1,260 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PackageDirectory,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Version,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Source,
+
+  [Parameter(Mandatory = $true)]
+  [string]$ApiKey,
+
+  [ValidateSet('NuGetOrg', 'GitHubPackages')]
+  [string]$Registry = 'NuGetOrg',
+
+  [string]$RepositoryOwner,
+
+  [string]$GitHubToken
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+Import-Module (Join-Path $PSScriptRoot 'PackageCatalog.psm1') -Force
+
+function Fail {
+  param([string]$Message)
+  throw "Package publication failed: $Message"
+}
+
+function Get-NuGetFlatContainerUrl {
+  param(
+    [string]$PackageId,
+    [string]$PackageVersion
+  )
+
+  $idLower = $PackageId.ToLowerInvariant()
+  $versionLower = $PackageVersion.ToLowerInvariant()
+  return "https://api.nuget.org/v3-flatcontainer/$idLower/$versionLower/$idLower.$versionLower.nupkg"
+}
+
+function Get-HttpStatus {
+  param([string]$Uri)
+
+  $status = (& curl `
+    --silent `
+    --show-error `
+    --location `
+    --proto '=https' `
+    --proto-redir '=https' `
+    --retry 3 `
+    --retry-delay 2 `
+    --retry-all-errors `
+    --connect-timeout 10 `
+    --max-time 30 `
+    --output /dev/null `
+    --write-out '%{http_code}' `
+    $Uri).Trim()
+
+  if ($LASTEXITCODE -ne 0) {
+    Fail "Unable to query '$Uri'."
+  }
+
+  return $status
+}
+
+function Assert-NuGetOrgPackageMatches {
+  param(
+    [string]$PackageId,
+    [string]$LocalPackagePath
+  )
+
+  $url = Get-NuGetFlatContainerUrl -PackageId $PackageId -PackageVersion $Version
+  $downloadPath = Join-Path ([System.IO.Path]::GetTempPath()) "$([System.Guid]::NewGuid()).nupkg"
+
+  try {
+    & curl `
+      --fail-with-body `
+      --silent `
+      --show-error `
+      --location `
+      --proto '=https' `
+      --proto-redir '=https' `
+      --retry 3 `
+      --retry-delay 2 `
+      --retry-all-errors `
+      --connect-timeout 10 `
+      --max-time 60 `
+      --output $downloadPath `
+      $url
+
+    if ($LASTEXITCODE -ne 0) {
+      Fail "Unable to download existing NuGet.org package $PackageId $Version for artifact comparison."
+    }
+
+    $localHash = (Get-FileHash -LiteralPath $LocalPackagePath -Algorithm SHA256).Hash.ToLowerInvariant()
+    $remoteHash = (Get-FileHash -LiteralPath $downloadPath -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($localHash -ne $remoteHash) {
+      Fail "NuGet.org already has $PackageId $Version, but its SHA-256 '$remoteHash' does not match local artifact '$localHash'. Refusing to mask an artifact mismatch."
+    }
+
+    Write-Host "NuGet.org: validated existing $PackageId $Version against the local artifact hash; skipping push."
+  }
+  finally {
+    if (Test-Path -LiteralPath $downloadPath) {
+      Remove-Item -LiteralPath $downloadPath -Force
+    }
+  }
+}
+
+function Test-GitHubPackageVersionExists {
+  param([string]$PackageId)
+
+  if ([string]::IsNullOrWhiteSpace($RepositoryOwner) -or [string]::IsNullOrWhiteSpace($GitHubToken)) {
+    Fail 'RepositoryOwner and GitHubToken are required to preflight GitHub Packages publication.'
+  }
+
+  $escapedPackageId = [System.Uri]::EscapeDataString($PackageId)
+  $headers = @{
+    Authorization = "Bearer $GitHubToken"
+    Accept = 'application/vnd.github+json'
+    'X-GitHub-Api-Version' = '2022-11-28'
+    'User-Agent' = 'Dapper-FluentMap-release-publish'
+  }
+  $page = 1
+
+  while ($true) {
+    $uri = "https://api.github.com/users/$RepositoryOwner/packages/nuget/$escapedPackageId/versions?per_page=100&page=$page"
+    $response = Invoke-WebRequest -Uri $uri -Method Get -Headers $headers -SkipHttpErrorCheck
+    $status = [int]$response.StatusCode
+
+    if ($status -eq 404) {
+      return $false
+    }
+
+    if ($status -ne 200) {
+      Fail "GitHub Packages lookup for $PackageId returned HTTP $status."
+    }
+
+    $versions = @($response.Content | ConvertFrom-Json)
+    if (@($versions | Where-Object { [string]$_.name -eq $Version }).Count -gt 0) {
+      return $true
+    }
+
+    if ($versions.Count -lt 100) {
+      return $false
+    }
+
+    $page++
+  }
+}
+
+function Invoke-DotNetNuGetPush {
+  param(
+    [string]$PackageId,
+    [string]$PackagePath
+  )
+
+  Write-Host "> dotnet nuget push $PackagePath --source $Source --api-key ***"
+  $output = & dotnet nuget push $PackagePath `
+    --source $Source `
+    --api-key $ApiKey 2>&1
+  $exitCode = $LASTEXITCODE
+
+  $output | ForEach-Object { Write-Host $_ }
+
+  if ($exitCode -ne 0) {
+    Fail "$Registry publication failed for $PackageId $Version from '$PackagePath' with exit code $exitCode. The original dotnet nuget push output is shown above."
+  }
+}
+
+function Wait-NuGetOrgPackageVisible {
+  param(
+    [string]$PackageId,
+    [string]$PackagePath
+  )
+
+  $url = Get-NuGetFlatContainerUrl -PackageId $PackageId -PackageVersion $Version
+  for ($attempt = 1; $attempt -le 12; $attempt++) {
+    $status = Get-HttpStatus -Uri $url
+    if ($status -eq '200') {
+      Assert-NuGetOrgPackageMatches -PackageId $PackageId -LocalPackagePath $PackagePath
+      return
+    }
+
+    if ($status -ne '404') {
+      Fail "Unexpected NuGet.org response HTTP $status while waiting for $PackageId $Version."
+    }
+
+    Start-Sleep -Seconds 10
+  }
+
+  Fail "NuGet.org did not expose $PackageId $Version after publication within the retry window."
+}
+
+function Wait-GitHubPackageVisible {
+  param([string]$PackageId)
+
+  for ($attempt = 1; $attempt -le 12; $attempt++) {
+    if (Test-GitHubPackageVersionExists -PackageId $PackageId) {
+      Write-Host "GitHub Packages: verified $PackageId $Version after publication."
+      return
+    }
+
+    Start-Sleep -Seconds 10
+  }
+
+  Fail "GitHub Packages did not expose $PackageId $Version after publication within the retry window."
+}
+
+if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+  Fail "$Registry API key is empty."
+}
+
+$packageRoot = (Resolve-Path -LiteralPath $PackageDirectory).Path
+$packages = @(Get-FluentMapPackages)
+
+foreach ($package in $packages) {
+  $packageId = [string]$package.packageId
+  $packageName = Get-FluentMapPackageFileName -Package $package -Version $Version
+  $packagePath = Join-Path $packageRoot $packageName
+  if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+    Fail "Expected package artifact '$packageName' was not found in '$packageRoot'."
+  }
+
+  if ($Registry -eq 'NuGetOrg') {
+    $status = Get-HttpStatus -Uri (Get-NuGetFlatContainerUrl -PackageId $packageId -PackageVersion $Version)
+    switch ($status) {
+      '200' {
+        Assert-NuGetOrgPackageMatches -PackageId $packageId -LocalPackagePath $packagePath
+        continue
+      }
+      '404' {
+        Write-Host "NuGet.org: $packageId $Version is not currently published; publishing local artifact."
+      }
+      default {
+        Fail "Unexpected NuGet.org response HTTP $status for $packageId $Version. Failing closed."
+      }
+    }
+  }
+  elseif (Test-GitHubPackageVersionExists -PackageId $packageId) {
+    Write-Host "GitHub Packages: validated that $packageId $Version already exists; skipping push."
+    continue
+  }
+  else {
+    Write-Host "GitHub Packages: $packageId $Version is not currently published; publishing local artifact."
+  }
+
+  Invoke-DotNetNuGetPush -PackageId $packageId -PackagePath $packagePath
+  if ($Registry -eq 'NuGetOrg') {
+    Wait-NuGetOrgPackageVisible -PackageId $packageId -PackagePath $packagePath
+  }
+  else {
+    Wait-GitHubPackageVisible -PackageId $packageId
+  }
+}
+
+Write-Host "$Registry publication completed for $($packages.Count) package identities."

--- a/eng/publish-package-set.ps1
+++ b/eng/publish-package-set.ps1
@@ -101,7 +101,7 @@ function Assert-NuGetOrgPackageMatches {
       Fail "NuGet.org already has $PackageId $Version, but its SHA-256 '$remoteHash' does not match local artifact '$localHash'. Refusing to mask an artifact mismatch."
     }
 
-    Write-Host "NuGet.org: validated existing $PackageId $Version against the local artifact hash; skipping push."
+    Write-Output "NuGet.org: validated existing $PackageId $Version against the local artifact hash; skipping push."
   }
   finally {
     if (Test-Path -LiteralPath $downloadPath) {
@@ -158,13 +158,13 @@ function Invoke-DotNetNuGetPush {
     [string]$PackagePath
   )
 
-  Write-Host "> dotnet nuget push $PackagePath --source $Source --api-key ***"
+  Write-Output "> dotnet nuget push $PackagePath --source $Source --api-key ***"
   $output = & dotnet nuget push $PackagePath `
     --source $Source `
     --api-key $ApiKey 2>&1
   $exitCode = $LASTEXITCODE
 
-  $output | ForEach-Object { Write-Host $_ }
+  $output | ForEach-Object { Write-Output $_ }
 
   if ($exitCode -ne 0) {
     Fail "$Registry publication failed for $PackageId $Version from '$PackagePath' with exit code $exitCode. The original dotnet nuget push output is shown above."
@@ -200,7 +200,7 @@ function Wait-GitHubPackageVisible {
 
   for ($attempt = 1; $attempt -le 12; $attempt++) {
     if (Test-GitHubPackageVersionExists -PackageId $PackageId) {
-      Write-Host "GitHub Packages: verified $PackageId $Version after publication."
+      Write-Output "GitHub Packages: verified $PackageId $Version after publication."
       return
     }
 
@@ -233,7 +233,7 @@ foreach ($package in $packages) {
         continue
       }
       '404' {
-        Write-Host "NuGet.org: $packageId $Version is not currently published; publishing local artifact."
+        Write-Output "NuGet.org: $packageId $Version is not currently published; publishing local artifact."
       }
       default {
         Fail "Unexpected NuGet.org response HTTP $status for $packageId $Version. Failing closed."
@@ -241,11 +241,11 @@ foreach ($package in $packages) {
     }
   }
   elseif (Test-GitHubPackageVersionExists -PackageId $packageId) {
-    Write-Host "GitHub Packages: validated that $packageId $Version already exists; skipping push."
+    Write-Output "GitHub Packages: validated that $packageId $Version already exists; skipping push."
     continue
   }
   else {
-    Write-Host "GitHub Packages: $packageId $Version is not currently published; publishing local artifact."
+    Write-Output "GitHub Packages: $packageId $Version is not currently published; publishing local artifact."
   }
 
   Invoke-DotNetNuGetPush -PackageId $packageId -PackagePath $packagePath
@@ -257,4 +257,4 @@ foreach ($package in $packages) {
   }
 }
 
-Write-Host "$Registry publication completed for $($packages.Count) package identities."
+Write-Output "$Registry publication completed for $($packages.Count) package identities."

--- a/eng/rollback-release.ps1
+++ b/eng/rollback-release.ps1
@@ -9,23 +9,16 @@ param(
     [string]$Repository,
 
     [Parameter(Mandatory = $true)]
-    [string]$RepositoryOwner,
-
-    [Parameter(Mandatory = $true)]
     [string]$GitHubToken,
 
-    [string]$NuGetApiKey
+    [switch]$DeleteReleaseTag
 )
 
 $ErrorActionPreference = 'Stop'
 
-Import-Module (Join-Path $PSScriptRoot 'PackageCatalog.psm1') -Force
-
 if ($Version -eq '3.0.0' -or $ReleaseTag -eq 'v3.0.0') {
     throw 'Version 3.0.0 and tag v3.0.0 are immutable historical artifacts and must not be modified by rollback automation.'
 }
-
-$packageIds = @(Get-FluentMapPackageIds)
 
 $failures = [System.Collections.Generic.List[string]]::new()
 
@@ -67,93 +60,8 @@ function Invoke-GitHubRequest {
 }
 
 Write-Host "Starting compensating rollback for $ReleaseTag ($Version)."
-Write-Host 'NuGet.org cannot permanently delete a published version; rollback unlists versions that were created before the release failed.'
-
-# NuGet.org compensation: unlist any target package version that exists.
-if ([string]::IsNullOrWhiteSpace($NuGetApiKey)) {
-    Add-RollbackFailure 'No temporary NuGet API key was available for rollback. Ensure the Trusted Publishing policy grants Unlist/relist scope.'
-}
-else {
-    foreach ($packageId in $packageIds) {
-        $escapedId = [System.Uri]::EscapeDataString($packageId)
-        $escapedVersion = [System.Uri]::EscapeDataString($Version)
-        $uri = "https://www.nuget.org/api/v2/package/$escapedId/$escapedVersion"
-
-        try {
-            $response = Invoke-WebRequest `
-                -Uri $uri `
-                -Method Delete `
-                -Headers @{ 'X-NuGet-ApiKey' = $NuGetApiKey } `
-                -SkipHttpErrorCheck
-
-            switch ([int]$response.StatusCode) {
-                204 { Write-Host "NuGet.org: unlisted $packageId $Version." }
-                404 { Write-Host "NuGet.org: $packageId $Version was not published; nothing to unlist." }
-                default {
-                    Add-RollbackFailure "NuGet.org rollback for $packageId $Version returned HTTP $([int]$response.StatusCode)."
-                }
-            }
-        }
-        catch {
-            Add-RollbackFailure "NuGet.org rollback failed for $packageId $Version`: $($_.Exception.Message)"
-        }
-    }
-}
-
-# GitHub Packages compensation: delete this version from each NuGet package.
-foreach ($packageId in $packageIds) {
-    $escapedPackageId = [System.Uri]::EscapeDataString($packageId)
-    $versionIds = [System.Collections.Generic.List[long]]::new()
-    $page = 1
-
-    while ($true) {
-        $listUri = "https://api.github.com/users/$RepositoryOwner/packages/nuget/$escapedPackageId/versions?per_page=100&page=$page"
-        $response = Invoke-GitHubRequest -Method GET -Uri $listUri
-        if ($null -eq $response) {
-            break
-        }
-
-        $status = [int]$response.StatusCode
-        if ($status -eq 404) {
-            Write-Host "GitHub Packages: $packageId does not exist; nothing to delete."
-            break
-        }
-
-        if ($status -ne 200) {
-            Add-RollbackFailure "GitHub Packages lookup for $packageId returned HTTP $status."
-            break
-        }
-
-        $versions = @($response.Content | ConvertFrom-Json)
-        foreach ($packageVersion in $versions) {
-            if ([string]$packageVersion.name -eq $Version) {
-                $versionIds.Add([long]$packageVersion.id)
-            }
-        }
-
-        if ($versions.Count -lt 100) {
-            break
-        }
-
-        $page++
-    }
-
-    foreach ($versionId in $versionIds) {
-        $deleteUri = "https://api.github.com/users/$RepositoryOwner/packages/nuget/$escapedPackageId/versions/$versionId"
-        $deleteResponse = Invoke-GitHubRequest -Method DELETE -Uri $deleteUri
-        if ($null -eq $deleteResponse) {
-            continue
-        }
-
-        $deleteStatus = [int]$deleteResponse.StatusCode
-        if ($deleteStatus -in @(204, 404)) {
-            Write-Host "GitHub Packages: deleted $packageId $Version (version id $versionId)."
-        }
-        else {
-            Add-RollbackFailure "GitHub Packages deletion for $packageId $Version returned HTTP $deleteStatus."
-        }
-    }
-}
+Write-Host 'Package registry artifacts are not deleted, unlisted, or overwritten by rollback.'
+Write-Host 'A partial registry publication is recovered by validating existing package identities and publishing only genuinely missing packages.'
 
 # Remove a partially-created GitHub Release, if any.
 $escapedTag = [System.Uri]::EscapeDataString($ReleaseTag)
@@ -175,16 +83,20 @@ if ($null -ne $releaseLookup) {
     }
 }
 
-# Remove the release tag last, after registry compensation has been attempted.
-$tagDelete = Invoke-GitHubRequest -Method DELETE -Uri "https://api.github.com/repos/$Repository/git/refs/tags/$escapedTag"
-if ($null -ne $tagDelete) {
-    $tagStatus = [int]$tagDelete.StatusCode
-    if ($tagStatus -in @(204, 404, 422)) {
-        Write-Host "Git tag: removed or already absent: $ReleaseTag."
+if ($DeleteReleaseTag) {
+    $tagDelete = Invoke-GitHubRequest -Method DELETE -Uri "https://api.github.com/repos/$Repository/git/refs/tags/$escapedTag"
+    if ($null -ne $tagDelete) {
+        $tagStatus = [int]$tagDelete.StatusCode
+        if ($tagStatus -in @(204, 404, 422)) {
+            Write-Host "Git tag: removed or already absent: $ReleaseTag."
+        }
+        else {
+            Add-RollbackFailure "Git tag deletion for $ReleaseTag returned HTTP $tagStatus."
+        }
     }
-    else {
-        Add-RollbackFailure "Git tag deletion for $ReleaseTag returned HTTP $tagStatus."
-    }
+}
+else {
+    Write-Host "Git tag: retained $ReleaseTag because it was not created by this workflow run."
 }
 
 if ($failures.Count -gt 0) {

--- a/eng/rollback-release.ps1
+++ b/eng/rollback-release.ps1
@@ -19,13 +19,13 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
-$packageIds = @(
-    'Dapper.FluentMap',
-    'Dapper.FluentMap.Dommel',
-    'Dapper.FluentMap.DependencyInjection',
-    'Dapper.FluentMap.Analyzers',
-    'Dapper.FluentMap.Generators'
-)
+Import-Module (Join-Path $PSScriptRoot 'PackageCatalog.psm1') -Force
+
+if ($Version -eq '3.0.0' -or $ReleaseTag -eq 'v3.0.0') {
+    throw 'Version 3.0.0 and tag v3.0.0 are immutable historical artifacts and must not be modified by rollback automation.'
+}
+
+$packageIds = @(Get-FluentMapPackageIds)
 
 $failures = [System.Collections.Generic.List[string]]::new()
 

--- a/eng/validate-package-metadata.ps1
+++ b/eng/validate-package-metadata.ps1
@@ -7,35 +7,55 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Import-Module (Join-Path $PSScriptRoot 'PackageCatalog.psm1') -Force
+
 $expectedRepositoryUrl = 'https://github.com/rodri-oliveira-dev/Dapper-FluentMap'
 $expectedReleaseNotesUrl = 'https://github.com/rodri-oliveira-dev/Dapper-FluentMap/releases'
 $expectedAuthors = @('Henk Mollema', 'Rodrigo de Oliveira')
-$expectedPackages = @{
-  'Dapper.FluentMap' = @{
-    Title = 'Dapper.FluentMap'
-    RequiredTags = @('dapper', 'fluent-mapping', 'mapping', 'micro-orm', 'database', 'sql', 'poco', 'fluentmap')
-  }
-  'Dapper.FluentMap.Dommel' = @{
-    Title = 'Dapper.FluentMap - Dommel Integration'
-    RequiredTags = @('dapper', 'dommel', 'fluent-mapping', 'mapping', 'crud', 'database', 'sql', 'fluentmap')
-  }
-  'Dapper.FluentMap.DependencyInjection' = @{
-    Title = 'Dapper.FluentMap - Dependency Injection'
-    RequiredTags = @('dapper', 'dependency-injection', 'di', 'fluent-mapping', 'mapping', 'database', 'fluentmap')
-  }
-  'Dapper.FluentMap.Analyzers' = @{
-    Title = 'Dapper.FluentMap Analyzers'
-    RequiredTags = @('dapper', 'roslyn', 'analyzers', 'mapping', 'diagnostics', 'fluent-mapping', 'fluentmap')
-  }
-  'Dapper.FluentMap.Generators' = @{
-    Title = 'Dapper.FluentMap Source Generators'
-    RequiredTags = @('dapper', 'roslyn', 'source-generator', 'mapping', 'code-generation', 'fluent-mapping', 'fluentmap')
-  }
-}
 
 function Fail {
   param([string]$Message)
   throw "NuGet package metadata validation failed: $Message"
+}
+
+$catalogPackages = @(Get-FluentMapPackages)
+$expectedPackages = @{}
+foreach ($package in $catalogPackages) {
+  $expectedPackages[[string]$package.packageId] = switch ([string]$package.project) {
+    'Dapper.FluentMap' {
+      @{
+        Title = 'Dapper.FluentMap'
+        RequiredTags = @('dapper', 'fluent-mapping', 'mapping', 'micro-orm', 'database', 'sql', 'poco', 'fluentmap')
+      }
+    }
+    'Dapper.FluentMap.Dommel' {
+      @{
+        Title = 'Dapper.FluentMap - Dommel Integration'
+        RequiredTags = @('dapper', 'dommel', 'fluent-mapping', 'mapping', 'crud', 'database', 'sql', 'fluentmap')
+      }
+    }
+    'Dapper.FluentMap.DependencyInjection' {
+      @{
+        Title = 'Dapper.FluentMap - Dependency Injection'
+        RequiredTags = @('dapper', 'dependency-injection', 'di', 'fluent-mapping', 'mapping', 'database', 'fluentmap')
+      }
+    }
+    'Dapper.FluentMap.Analyzers' {
+      @{
+        Title = 'Dapper.FluentMap Analyzers'
+        RequiredTags = @('dapper', 'roslyn', 'analyzers', 'mapping', 'diagnostics', 'fluent-mapping', 'fluentmap')
+      }
+    }
+    'Dapper.FluentMap.Generators' {
+      @{
+        Title = 'Dapper.FluentMap Source Generators'
+        RequiredTags = @('dapper', 'roslyn', 'source-generator', 'mapping', 'code-generation', 'fluent-mapping', 'fluentmap')
+      }
+    }
+    default {
+      Fail "Package catalog contains unexpected project identity '$($package.project)'."
+    }
+  }
 }
 
 function Get-ChildText {

--- a/eng/validate-release-artifacts.ps1
+++ b/eng/validate-release-artifacts.ps1
@@ -20,40 +20,47 @@ param(
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 
+Import-Module (Join-Path $PSScriptRoot 'PackageCatalog.psm1') -Force
+
 $expectedRepositoryUrl = 'https://github.com/rodri-oliveira-dev/Dapper-FluentMap'
-$expectedNupkgIds = @(
-  'Dapper.FluentMap',
-  'Dapper.FluentMap.Dommel',
-  'Dapper.FluentMap.DependencyInjection',
-  'Dapper.FluentMap.Analyzers',
-  'Dapper.FluentMap.Generators'
-)
-$expectedSnupkgIds = @(
-  'Dapper.FluentMap',
-  'Dapper.FluentMap.Dommel',
-  'Dapper.FluentMap.DependencyInjection'
-)
-$expectedDependencies = @{
-  'Dapper.FluentMap' = @{
-    'Dapper' = '[2.1.79, 3.0.0)'
-    'Microsoft.Bcl.AsyncInterfaces' = '10.0.11'
-  }
-  'Dapper.FluentMap.Dommel' = @{
-    'Dapper.FluentMap' = $Version
-    'Dapper' = '[2.1.79, 3.0.0)'
-    'Dommel' = '[3.5.3, 4.0.0)'
-  }
-  'Dapper.FluentMap.DependencyInjection' = @{
-    'Dapper.FluentMap' = $Version
-    'Microsoft.Extensions.DependencyInjection.Abstractions' = '10.0.11'
-  }
-  'Dapper.FluentMap.Analyzers' = @{}
-  'Dapper.FluentMap.Generators' = @{}
-}
 
 function Fail {
   param([string]$Message)
   throw "Release artifact validation failed: $Message"
+}
+
+$catalogPackages = @(Get-FluentMapPackages)
+$symbolCatalogPackages = @(Get-FluentMapPackages -WithSymbols)
+$expectedNupkgIds = @($catalogPackages | ForEach-Object { [string]$_.packageId })
+$expectedSnupkgIds = @($symbolCatalogPackages | ForEach-Object { [string]$_.packageId })
+$expectedDependencies = @{}
+foreach ($package in $catalogPackages) {
+  $expectedDependencies[[string]$package.packageId] = switch ([string]$package.project) {
+    'Dapper.FluentMap' {
+      @{
+        'Dapper' = '[2.1.79, 3.0.0)'
+        'Microsoft.Bcl.AsyncInterfaces' = '10.0.11'
+      }
+    }
+    'Dapper.FluentMap.Dommel' {
+      @{
+        'Dapper.FluentMap' = $Version
+        'Dapper' = '[2.1.79, 3.0.0)'
+        'Dommel' = '[3.5.3, 4.0.0)'
+      }
+    }
+    'Dapper.FluentMap.DependencyInjection' {
+      @{
+        'Dapper.FluentMap' = $Version
+        'Microsoft.Extensions.DependencyInjection.Abstractions' = '10.0.11'
+      }
+    }
+    'Dapper.FluentMap.Analyzers' { @{} }
+    'Dapper.FluentMap.Generators' { @{} }
+    default {
+      Fail "Package catalog contains unexpected project identity '$($package.project)'."
+    }
+  }
 }
 
 function Get-GitOutput {
@@ -359,16 +366,16 @@ $nupkgs = @(Get-ChildItem -LiteralPath $packageRoot -Filter '*.nupkg' -File | So
 $snupkgs = @(Get-ChildItem -LiteralPath $packageRoot -Filter '*.snupkg' -File | Sort-Object Name)
 $allArtifacts = @($nupkgs + $snupkgs)
 
-if ($nupkgs.Count -ne 5) {
-  Fail "Expected 5 .nupkg files, found $($nupkgs.Count)."
+if ($nupkgs.Count -ne $expectedNupkgIds.Count) {
+  Fail "Expected $($expectedNupkgIds.Count) .nupkg files, found $($nupkgs.Count)."
 }
 
-if ($snupkgs.Count -ne 3) {
-  Fail "Expected 3 .snupkg files, found $($snupkgs.Count)."
+if ($snupkgs.Count -ne $expectedSnupkgIds.Count) {
+  Fail "Expected $($expectedSnupkgIds.Count) .snupkg files, found $($snupkgs.Count)."
 }
 
-$expectedNupkgNames = @($expectedNupkgIds | ForEach-Object { "$_.$Version.nupkg" })
-$expectedSnupkgNames = @($expectedSnupkgIds | ForEach-Object { "$_.$Version.snupkg" })
+$expectedNupkgNames = @($catalogPackages | ForEach-Object { Get-FluentMapPackageFileName -Package $_ -Version $Version })
+$expectedSnupkgNames = @($symbolCatalogPackages | ForEach-Object { Get-FluentMapPackageFileName -Package $_ -Version $Version -Kind symbols })
 Assert-SetEquals -Expected $expectedNupkgNames -Actual ([string[]]@($nupkgs.Name)) -Description '.nupkg file set'
 Assert-SetEquals -Expected $expectedSnupkgNames -Actual ([string[]]@($snupkgs.Name)) -Description '.snupkg file set'
 
@@ -398,19 +405,23 @@ foreach ($file in $nupkgs) {
 
 Assert-SetEquals -Expected $expectedNupkgIds -Actual ([string[]]$packageInfos.Keys) -Description '.nupkg package IDs'
 
-foreach ($id in @('Dapper.FluentMap', 'Dapper.FluentMap.Dommel', 'Dapper.FluentMap.DependencyInjection')) {
-  $expectedDll = "lib/netstandard2.0/$id.dll"
-  $expectedXml = "lib/netstandard2.0/$id.xml"
+foreach ($package in @($catalogPackages | Where-Object { $_.assetKind -eq 'library' })) {
+  $id = [string]$package.packageId
+  $assemblyName = [string]$package.project
+  $expectedDll = "lib/netstandard2.0/$assemblyName.dll"
+  $expectedXml = "lib/netstandard2.0/$assemblyName.xml"
   $info = $packageInfos[$id]
   if ($expectedDll -notin $info.Entries -or $expectedXml -notin $info.Entries) {
     Fail "$id must include $expectedDll and $expectedXml."
   }
 }
 
-foreach ($id in @('Dapper.FluentMap.Analyzers', 'Dapper.FluentMap.Generators')) {
+foreach ($package in @($catalogPackages | Where-Object { $_.assetKind -eq 'analyzer' })) {
+  $id = [string]$package.packageId
+  $assemblyName = [string]$package.project
   $info = $packageInfos[$id]
-  $expectedDll = "analyzers/dotnet/cs/$id.dll"
-  $expectedPdb = "analyzers/dotnet/cs/$id.pdb"
+  $expectedDll = "analyzers/dotnet/cs/$assemblyName.dll"
+  $expectedPdb = "analyzers/dotnet/cs/$assemblyName.pdb"
   if ($expectedDll -notin $info.Entries -or $expectedPdb -notin $info.Entries) {
     Fail "$id must use analyzer package layout under analyzers/dotnet/cs."
   }
@@ -427,7 +438,12 @@ foreach ($file in $snupkgs) {
   $info = Get-ZipPackageInfo -File $file
   Assert-CommonPackageMetadata -PackageInfo $info -ExpectedId $expectedId -RequireReadmeAndLicense $false
 
-  $expectedPdb = "lib/netstandard2.0/$expectedId.pdb"
+  $symbolPackage = $symbolCatalogPackages | Where-Object { $_.packageId -eq $expectedId } | Select-Object -First 1
+  if ($null -eq $symbolPackage) {
+    Fail "Unexpected symbol package ID '$expectedId'."
+  }
+
+  $expectedPdb = "lib/netstandard2.0/$($symbolPackage.project).pdb"
   if ($expectedPdb -notin $info.Entries) {
     Fail "$expectedId symbol package must include $expectedPdb."
   }
@@ -483,9 +499,10 @@ $manifestJson = $manifest | ConvertTo-Json -Depth 8
   $manifestJson + [Environment]::NewLine,
   [System.Text.UTF8Encoding]::new($false))
 
+$expectedArtifactCount = $expectedNupkgIds.Count + $expectedSnupkgIds.Count
 $validatedManifest = Get-Content -Raw -Path $manifestFullPath | ConvertFrom-Json
-if ($validatedManifest.version -ne $Version -or @($validatedManifest.packages).Count -ne 8) {
+if ($validatedManifest.version -ne $Version -or @($validatedManifest.packages).Count -ne $expectedArtifactCount) {
   Fail "Generated manifest '$manifestFullPath' did not round-trip with the expected version and package count."
 }
 
-Write-Host "Validated 5 .nupkg files, 3 .snupkg files and wrote manifest '$manifestFullPath' for $Version."
+Write-Host "Validated $($expectedNupkgIds.Count) .nupkg files, $($expectedSnupkgIds.Count) .snupkg files and wrote manifest '$manifestFullPath' for $Version."

--- a/src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj
+++ b/src/Dapper.FluentMap.Analyzers/Dapper.FluentMap.Analyzers.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <PackageId>Dapper.FluentMap.Analyzers</PackageId>
+    <PackageId>FluentMap.Analyzers</PackageId>
     <PackageTags>dapper;roslyn;analyzers;mapping;diagnostics;fluent-mapping;fluentmap</PackageTags>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeSymbols>false</IncludeSymbols>

--- a/src/Dapper.FluentMap.Analyzers/README.md
+++ b/src/Dapper.FluentMap.Analyzers/README.md
@@ -1,11 +1,13 @@
-# Dapper.FluentMap.Analyzers
+# FluentMap.Analyzers
 
 Roslyn analyzers for statically provable `Dapper.FluentMap` configuration errors.
 
 Install it alongside the core package when you want compile-time feedback for invalid map expressions, duplicate member paths, duplicate columns, invalid `IncludeBase<TBase>()` usage, invalid generic map/profile registration, invalid type-based property converters and duplicate converter configuration in a fluent chain.
 
 ```bash
-dotnet add package Dapper.FluentMap.Analyzers
+dotnet add package FluentMap.Analyzers
 ```
+
+The NuGet PackageId is `FluentMap.Analyzers`. The analyzer assembly remains `Dapper.FluentMap.Analyzers.dll`.
 
 The analyzer package complements runtime validation. It does not execute user mapping constructors, scan assemblies, access databases or replace `FluentMapper.Validate()`.

--- a/src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj
+++ b/src/Dapper.FluentMap.DependencyInjection/Dapper.FluentMap.DependencyInjection.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageId>Dapper.FluentMap.DependencyInjection</PackageId>
+    <PackageId>FluentMap.DependencyInjection</PackageId>
     <PackageTags>dapper;dependency-injection;di;fluent-mapping;mapping;database;fluentmap</PackageTags>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>

--- a/src/Dapper.FluentMap.DependencyInjection/README.md
+++ b/src/Dapper.FluentMap.DependencyInjection/README.md
@@ -1,6 +1,12 @@
-# Dapper.FluentMap.DependencyInjection
+# FluentMap.DependencyInjection
 
 Dependency injection integration for Dapper.FluentMap.
+
+```bash
+dotnet add package FluentMap.DependencyInjection
+```
+
+The NuGet PackageId is `FluentMap.DependencyInjection`. The assembly and C# namespace remain `Dapper.FluentMap.DependencyInjection`.
 
 ```csharp
 using Microsoft.Extensions.DependencyInjection;

--- a/src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj
+++ b/src/Dapper.FluentMap.Generators/Dapper.FluentMap.Generators.csproj
@@ -6,7 +6,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <PackageId>Dapper.FluentMap.Generators</PackageId>
+    <PackageId>FluentMap.Generators</PackageId>
     <PackageTags>dapper;roslyn;source-generator;mapping;code-generation;fluent-mapping;fluentmap</PackageTags>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <IncludeSymbols>false</IncludeSymbols>

--- a/src/Dapper.FluentMap.Generators/README.md
+++ b/src/Dapper.FluentMap.Generators/README.md
@@ -1,12 +1,14 @@
-# Dapper.FluentMap.Generators
+# FluentMap.Generators
 
 Build-time source generator for Dapper.FluentMap mapping registration and supported row materializers.
 
 The generator discovers eligible `IEntityMap<TEntity>` implementations declared in the current compilation and emits an `AddGeneratedMappings()` extension method that registers them through the existing `AddMap<TMap>()` / `AddProfile<TMap>()` APIs. For explicit maps with literal columns and supported deterministic construction, it also registers generated `IDataRecord -> entity` materializers for the matching ordered column shape, including flat properties, nested object paths and constructor-built Value Objects.
 
 ```bash
-dotnet add package Dapper.FluentMap.Generators
+dotnet add package FluentMap.Generators
 ```
+
+The NuGet PackageId is `FluentMap.Generators`. The source-generator assembly remains `Dapper.FluentMap.Generators.dll`.
 
 ```csharp
 using Dapper.FluentMap;


### PR DESCRIPTION
## Agent governance

- Imported and adapted eleven repository-local .NET skills in total.
- Existing skills retained:
  - `dotnet-issue-implementation`
  - `dotnet-refactoring-engineer`
  - `dotnet-pr-review`
  - `dotnet-library-change`
  - `ci-release-governance`
- Added from/adapted from `dotnet/skills`:
  - `authoring-github-workflows`
  - `nuget-trusted-publishing`
  - `test-gap-analysis`
  - `microbenchmarking`
  - `directory-build-organization`
  - `binlog-failure-analysis`
- Added the required supporting `references/` files and `.agents/THIRD-PARTY-NOTICES.md` with MIT attribution to the .NET Foundation.
- Updated `AGENTS.md` with task routing and composition guidance for the new skills.
- Adapted the imported guidance to Dapper-FluentMap rather than copying template assumptions: `master` remains the default branch, the existing benchmark project is preferred, OIDC Trusted Publishing/release recovery remain authoritative, public packages preserve `netstandard2.0`, and the repository is correctly documented as using explicit `PackageReference` versions rather than Central Package Management.
- Documented that project identity, assembly identity, namespace identity and NuGet `PackageId` are independent identities.

## Architecture

- Added and configured ADR Guard as a repository-local .NET tool (`RodriOliveira.AdrGuard` 0.1.8).
- Added ADR [0001 - Decouple NuGet Package IDs from FluentMap project identities](docs/adr/0001-decouple-nuget-package-ids-from-fluentmap-project-identities.md), status `Accepted`.
- Introduced `eng/package-catalog.json` as the package catalog separating project identity from package identity.
- Renamed only the three new NuGet PackageIds:
  - `Dapper.FluentMap.DependencyInjection` -> `FluentMap.DependencyInjection`
  - `Dapper.FluentMap.Analyzers` -> `FluentMap.Analyzers`
  - `Dapper.FluentMap.Generators` -> `FluentMap.Generators`
- Preserved assemblies, namespaces, project names, project paths and public APIs.

## Release engineering

- Corrected NuGet preflight semantics so flat-container `404` is treated only as "PackageId/version is not currently published", not proof of publisher authorization.
- Improved `dotnet nuget push` diagnostics by keeping original command output and adding PackageId/version context.
- Improved partial-release recovery and idempotency by checking package-version state explicitly, validating existing NuGet.org artifacts with signature-aware package-content comparison, publishing only missing packages and accepting only tags that already point to the validated SHA.
- Made rollback non-destructive for package registries; partial registry publication is recovered through validation and publish-missing recovery instead of unlisting/deleting registry artifacts.
- Preserved OIDC Trusted Publishing and least-privilege permissions.
- Kept `v3.0.0` and the already published `Dapper.FluentMap`/`Dapper.FluentMap.Dommel` 3.0.0 artifacts immutable.
- Prepared the repository for a coherent `3.0.1` release across the full package family.

## Validation

Previous functional/release validation on `d80c58ae4f7d377eb34c1a22f3f216fd1927fd53` completed successfully:

```bash
dotnet tool restore
dotnet tool run adr-guard check docs/adr
dotnet tool run adr-guard index docs/adr
python -m check_jsonschema --builtin-schema vendor.github-workflows .github/workflows/*.yml
./eng/validate-slnx-equivalence.ps1
dotnet restore ./Dapper.FluentMap.slnx
dotnet build ./Dapper.FluentMap.slnx --configuration Release --no-restore
dotnet test ./Dapper.FluentMap.slnx --configuration Release --no-build
```

- Tests: 478 total, 464 passed, 14 skipped, 0 failed.
- Pack validation produced 5 `.nupkg` and 3 `.snupkg` artifacts for the 3.0.1 validation set.
- NuGet presentation metadata, release-artifact manifest and consumer-smoke validation passed.
- CI, repository configuration, analyzer/generator compatibility, Dapper compatibility, Pack, SonarQube Cloud and CI Gate passed on that functional head.

The subsequent agent-only commit `a22fa714253e96b17553edd33d8b1a5d5eeac5ab` adds 18 skill/reference/notice files and updates only `AGENTS.md`; no runtime source, project, release workflow, package identity or release script is changed. CI was triggered for this head to revalidate the repository.

## Package inspection

- `Dapper.FluentMap.3.0.1.nupkg` -> PackageId `Dapper.FluentMap`, assembly `Dapper.FluentMap.dll`.
- `Dapper.FluentMap.Dommel.3.0.1.nupkg` -> PackageId `Dapper.FluentMap.Dommel`, assembly `Dapper.FluentMap.Dommel.dll`.
- `FluentMap.DependencyInjection.3.0.1.nupkg` -> PackageId `FluentMap.DependencyInjection`, assembly `Dapper.FluentMap.DependencyInjection.dll`.
- `FluentMap.Analyzers.3.0.1.nupkg` -> PackageId `FluentMap.Analyzers`, analyzer assembly `analyzers/dotnet/cs/Dapper.FluentMap.Analyzers.dll`.
- `FluentMap.Generators.3.0.1.nupkg` -> PackageId `FluentMap.Generators`, analyzer assembly `analyzers/dotnet/cs/Dapper.FluentMap.Generators.dll`.

## Codex review

- Requested Codex review on the PR.
- Addressed three P1 findings from the first Codex review in `d80c58a`.
- Re-requested Codex review for that functional head; the Codex connector returned a transient ref-resolution error even though GitHub reported the SHA as the PR head and required checks passed.

No package, tag, or GitHub Release was published by this PR.

Note: `dotnet format ./Dapper.FluentMap.slnx --verify-no-changes --no-restore` reports pre-existing whitespace/EOL/charset issues in benchmark/test/source files outside this PR's edited code path, so no unrelated formatting cleanup is included.