### PR TITLE
fix: allow NuGet publication propagation before failing

### DIFF
--- a/eng/publish-package-set.ps1
+++ b/eng/publish-package-set.ps1
@@ -259,7 +259,10 @@ function Wait-NuGetOrgPackageVisible {
   )
 
   $url = Get-NuGetFlatContainerUrl -PackageId $PackageId -PackageVersion $Version
-  for ($attempt = 1; $attempt -le 12; $attempt++) {
+  $maxAttempts = 60
+  $delaySeconds = 10
+
+  for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
     $status = Get-HttpStatus -Uri $url
     if ($status -eq '200') {
       Assert-NuGetOrgPackageMatches -PackageId $PackageId -LocalPackagePath $PackagePath
@@ -270,10 +273,13 @@ function Wait-NuGetOrgPackageVisible {
       Fail "Unexpected NuGet.org response HTTP $status while waiting for $PackageId $Version."
     }
 
-    Start-Sleep -Seconds 10
+    if ($attempt -lt $maxAttempts) {
+      Write-Output "NuGet.org: waiting for $PackageId $Version to become visible ($attempt/$maxAttempts); retrying in $delaySeconds seconds."
+      Start-Sleep -Seconds $delaySeconds
+    }
   }
 
-  Fail "NuGet.org did not expose $PackageId $Version after publication within the retry window."
+  Fail "NuGet.org did not expose $PackageId $Version after publication within the 10-minute retry window."
 }
 
 function Wait-GitHubPackageVisible {


### PR DESCRIPTION
## Summary

Extends the NuGet.org post-publication visibility retry window so a successful package push is not reported as failed while NuGet is still indexing the package.

The release run `34391707436` successfully authenticated through Trusted Publishing and successfully pushed `Dapper.FluentMap 3.0.1`, but the workflow failed because the Flat Container endpoint still returned `404` for roughly two minutes after publication.

## Changes

- increases the NuGet.org visibility check from 12 attempts to 60 attempts;
- keeps the 10-second interval, allowing approximately 10 minutes for NuGet indexing/propagation;
- logs each pending visibility check with the current attempt count;
- avoids an unnecessary final sleep after the last attempt;
- makes the terminal error explicitly report the 10-minute retry window.

The existing fail-closed behavior and artifact-content verification remain unchanged.

## Validation

This is a focused PowerShell release-script change. GitHub Actions checks on this PR are the authoritative validation for repository build/test/governance behavior. A NuGet publication itself is intentionally not triggered from a pull request.

## Compatibility

No public API, package contents, or runtime library behavior is changed. The change only affects release-pipeline tolerance for NuGet.org indexing latency.